### PR TITLE
fix: 修复移动端侧栏抽屉交互问题

### DIFF
--- a/frontend/Game Console.html
+++ b/frontend/Game Console.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" />
   <link rel="stylesheet" href="src/tokens.css" />
   <link rel="stylesheet" href="src/platform.css?v=20260605-grid" />
-  <link rel="stylesheet" href="src/game-console.css?v=20260605-sidebar" />
+  <link rel="stylesheet" href="src/game-console.css?v=20260608-rail-fix" />
   <link rel="stylesheet" href="src/motion.css" />
 
   <!-- Vite: CDN UMD 脚本（React/ReactDOM/@babel/standalone）已移除

--- a/frontend/src/entries/game-console.jsx
+++ b/frontend/src/entries/game-console.jsx
@@ -1408,7 +1408,7 @@ function App() {
       {mountStage >= 1 ? <LeftRail
         resizeHandle={<div className="gc-rail-resize-handle" title="拖动调整宽度 · 双击恢复默认" {...gcRailDragProps} />}
         collapsed={railCollapsed}
-        onToggle={() => setRailCollapsed((c) => !c)}
+        onToggle={() => { setRailCollapsed((c) => !c); setMobileNav(false); }}
         state={game} runState={runState}
         onNew={() => { if (!confirm('新建存档需要选择剧本与角色,将跳到平台『存档目录』走正规创建流。\n\n确认跳转?')) return; window.open('/saves', '_blank'); }}
         onSave={async () => { try { await window.api.game.saveGame(); window.__apiToast?.('已保存', { kind: 'ok' }); } catch (e) { window.__apiToast?.('保存失败', { kind: 'danger', detail: e?.message }); } }}

--- a/frontend/src/game-console.css
+++ b/frontend/src/game-console.css
@@ -1605,6 +1605,14 @@
     box-shadow: 4px 0 24px rgba(0, 0, 0, 0.5);
     pointer-events: auto !important;
   }
+  /* 抽屉打开时重置 collapsed 对 inner 的 opacity/transform，
+     否则桌面态 .gc-rail.collapsed .gc-rail-inner {opacity:0} 仍生效 → 内容空白 */
+  .gc-rail.gc-rail-mobile-open .gc-rail-inner {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+  /* 手机端用汉堡按钮唤起抽屉，右箭头展开按钮多余且干扰，隐藏之 */
+  .gc-topbar-expand { display: none !important; }
   /* nav 抽屉 backdrop */
   .gc-nav-backdrop {
     display: block;


### PR DESCRIPTION
## 修复内容

### 问题 1：汉堡按钮展开抽屉后内容空白
移动端（≤768px）下，当侧栏处于 `collapsed` 状态时，`.gc-rail.collapsed .gc-rail-inner` 设置的 `opacity: 0` 和 `transform: translateX(-12px)` 未被移动端 CSS 覆盖，导致抽屉虽然滑入但内容不可见。

**修复**：在 `@media (max-width: 768px)` 块内添加：
```css
.gc-rail.gc-rail-mobile-open .gc-rail-inner {
  opacity: 1 !important;
  transform: none !important;
}
```

### 问题 2：移动端汉堡按钮与右箭头按钮同时显示
移动端下汉堡按钮通过 CSS 显示，但右箭头展开按钮（`.gc-topbar-expand`）仅由 JSX 的 `railCollapsed` 条件控制，在移动端也会显示，造成两个按钮并存。

**修复**：在移动端 CSS 中隐藏 `.gc-topbar-expand`。

### 问题 3：移动端点击侧栏内折叠按钮无效
侧栏内的「折叠侧栏」按钮只切换 `railCollapsed` 状态，但不关闭移动端抽屉（`mobileNav`），导致操作无效。

**修复**：`onToggle` 回调增加 `setMobileNav(false)`，使折叠按钮能同时关闭抽屉。

## 修改文件
- `frontend/src/game-console.css` — CSS 修复
- `frontend/src/entries/game-console.jsx` — JS 修复
- `frontend/Game Console.html` — CSS 缓存版本号更新