### PR TITLE
feat(scripts): 允许在剧本编辑器中删除 NPC 角色卡

### DIFF
--- a/frontend/src/pages/cards.jsx
+++ b/frontend/src/pages/cards.jsx
@@ -1339,10 +1339,11 @@ function NpcCardsView() {
    覆盖 user_character_cards 全部角色相关列:name / identity / aliases / tags /
    appearance / personality / speech_style / current_status / secrets /
    sample_dialogue / token_budget / priority / enabled / scope。 */
-function CardEditModal({ card, isNew, kind, onClose, onSave, targetScriptOptions = [], targetScriptId = "", onTargetScriptChange }) {
+function CardEditModal({ card, isNew, kind, onClose, onSave, onDelete, targetScriptOptions = [], targetScriptId = "", onTargetScriptChange }) {
   const { t } = useTranslation();
   const [form, setForm] = useStatePL(() => cardFormInit(card));
   const [submitting, setSubmitting] = useStatePL(false);
+  const [deleting, setDeleting] = useStatePL(false);
   const u = (k, v) => setForm(f => ({ ...f, [k]: v }));
   const nameOk = !!form.name.trim();
 
@@ -1352,6 +1353,23 @@ function CardEditModal({ card, isNew, kind, onClose, onSave, targetScriptOptions
     try { await onSave?.(cardFormPayload(form, card)); }
     catch (_) { /* 父级 onSaveCard 已 toast */ }
     finally { setSubmitting(false); }
+  };
+
+  // 删除入口:仅在编辑已存在卡片(非新建)时显示。删除前弹原生 confirm,
+  // 避免误触;父级 onDelete 负责实际 API + 列表刷新 + toast。
+  const doDelete = async () => {
+    if (isNew || deleting) return;
+    const ok = await window.__confirm?.({
+      title: t('cards.confirm.delete_title'),
+      message: t('cards.confirm.delete_message', { name: form.name || card?.name || '' }),
+      danger: true,
+      confirmText: t('cards.confirm.delete_btn'),
+    });
+    if (!ok) return;
+    setDeleting(true);
+    try { await onDelete?.(card); }
+    catch (_) { /* 父级 onDelete 已 toast */ }
+    finally { setDeleting(false); }
   };
 
   const node = (
@@ -1399,6 +1417,18 @@ function CardEditModal({ card, isNew, kind, onClose, onSave, targetScriptOptions
                     {isNew ? t('cards.editor.btn_create') : t('cards.editor.btn_save')}
                   </CSButton>
                   <CSButton variant="link" onClick={onClose}>{t('cards.editor.btn_cancel')}</CSButton>
+                  {/* 编辑已存在卡时,提供删除入口(新建态无 id,不可删) */}
+                  {!isNew && onDelete && (
+                    <CSButton
+                      iconName="remove"
+                      variant="link"
+                      onClick={doDelete}
+                      loading={deleting}
+                      disabled={deleting || submitting}
+                    >
+                      {t('cards.detail.btn_delete')}
+                    </CSButton>
+                  )}
                 </div>
               </CSSpaceBetween>
             </CSContainer>

--- a/frontend/src/pages/scripts.jsx
+++ b/frontend/src/pages/scripts.jsx
@@ -832,7 +832,32 @@ function ScriptDetailPanel({ script: s, savesCount, scriptSaves = [], embedStatu
                   <CSBox color="text-body-secondary" fontSize="body-s">{cardSnippet(c, 200) || '—'}</CSBox>
                 ) },
                 { id: 'act', content: (c) => (
-                  <CSButton variant="inline-link" iconName="edit" onClick={() => setNpcEdit({ card: c, isNew: false })}>{t('scripts.editor.view_edit')}</CSButton>
+                  <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+                    <CSButton variant="inline-link" iconName="edit" onClick={() => setNpcEdit({ card: c, isNew: false })}>{t('scripts.editor.view_edit')}</CSButton>
+                    {/* 删除入口:列表态就能用,不用先打开编辑模态框 */}
+                    <CSButton
+                      variant="inline-link"
+                      iconName="remove"
+                      onClick={async () => {
+                        if (!c || !c.id) return;
+                        const ok = await window.__confirm?.({
+                          title: t('cards.confirm.delete_title'),
+                          message: t('cards.confirm.delete_message', { name: c.name || '' }),
+                          danger: true,
+                          confirmText: t('cards.confirm.delete_btn'),
+                        });
+                        if (!ok) return;
+                        try {
+                          await window.api.cards.scriptDelete(s.id, c.id);
+                          window.__apiToast?.(t('cards.toast.deleted', { name: c.name || '' }), { kind: 'ok' });
+                          setNpc(null); // 触发 NPC 列表重新拉取
+                          try { window.dispatchEvent(new CustomEvent('rpg-scripts-updated')); } catch (_) {}
+                        } catch (e) {
+                          window.__apiToast?.(t('cards.toast.delete_fail'), { kind: 'danger', detail: e?.message || String(e) });
+                        }
+                      }}
+                    >{t('cards.detail.btn_delete')}</CSButton>
+                  </div>
                 ) },
               ],
             }}
@@ -923,6 +948,22 @@ function ScriptDetailPanel({ script: s, savesCount, scriptSaves = [], embedStatu
               setNpc(null); // 触发 NPC 列表重新拉取
             } catch (e) {
               window.__apiToast?.(t('scripts.toast.save_fail'), { kind: 'danger', detail: e?.message });
+            }
+          }}
+          /* 删除入口:仅在编辑已存在卡时显示。调后端 scriptDelete 端点,
+             然后清本地列表触发 reload。toast 复用 cards.toast.deleted / delete_fail。 */
+          onDelete={async (card) => {
+            const cardId = card?.id;
+            if (!cardId) throw new Error(t('cards.toast.npc_script_required'));
+            try {
+              await window.api.cards.scriptDelete(s.id, cardId);
+              window.__apiToast?.(t('cards.toast.deleted', { name: card.name || '' }), { kind: 'ok' });
+              setNpcEdit(null);
+              setNpc(null);
+              try { window.dispatchEvent(new CustomEvent('rpg-scripts-updated')); } catch (_) {}
+            } catch (e) {
+              window.__apiToast?.(t('cards.toast.delete_fail'), { kind: 'danger', detail: e?.message || String(e) });
+              throw e; // 让 CardEditModal 不进入提交中态
             }
           }}
         />


### PR DESCRIPTION
## 背景

在「剧本 → 选剧本 → NPC 角色卡」Tab 下,生成的 NPC 角色卡一旦跑歪(重复出现、错别字、合并剧本遗留),之前没有任何 UI 入口能删除 —— 只能通过后端 API 手动调,或者把整个剧本删掉重建。

更尴尬的是,i18n 文件里 `cards.toast.npc_delete_hint` 已经写明「NPC 卡在剧本管理页面删除」,但 UI 里压根没有对应按钮,等于是个 i18n 死链文案。

## 改动

新增两处删除入口,两条路径共用同一套流程:

1. **列表卡片**:`frontend/src/pages/scripts.jsx` 的 NPC `CSCards` `cardDefinition` 的 `act` section,在「查看/编辑」旁边新增「删除」内联链接 —— 用户无需先打开编辑器即可删除多余/错误的卡。
2. **编辑模态框**:`frontend/src/pages/cards.jsx` 的 `CardEditModal` 新增 `onDelete` prop;右栏「保存/取消」下方新增「删除」链接,仅在编辑已存在卡片(非新建)时显示 —— 新建态没有 id,无法删除,自然不显示。

### 共享删除流程

```js
const ok = await window.__confirm?.({ title, message, danger: true, confirmText });
if (!ok) return;
await window.api.cards.scriptDelete(s.id, c.id);   // POST /api/scripts/{sid}/character-cards/{cid}/delete
window.__apiToast?.(t('cards.toast.deleted', { name }), { kind: 'ok' });
setNpc(null);                                        // 触发 NPC 列表重新拉取
window.dispatchEvent(new CustomEvent('rpg-scripts-updated'));  // 跨标签页同步
```

后端端点已存在 (`rpg/platform_app/api/scripts.py` 的 `POST /api/scripts/{script_id}/character-cards/{card_id}/delete`),无需后端改动。

## i18n

全部复用现有键,无新增翻译:

- `cards.confirm.delete_title` / `cards.confirm.delete_message` / `cards.confirm.delete_btn`
- `cards.toast.deleted` / `cards.toast.delete_fail`
- `cards.detail.btn_delete`

## 验证

手动测试通过:
- 进入任一剧本 → NPC 角色卡 Tab
- 点列表卡片上的「删除」→ 弹原生危险确认框 → 确认 → 卡从列表消失
- 点「查看/编辑」打开模态框 → 右栏底部出现「删除」链接 → 同样流程
- 新建态模态框不显示「删除」(符合预期)
- 后端 `scriptDelete` 端点接受请求并返回成功

## 涉及文件

```
frontend/src/pages/cards.jsx   | 32 ++++++++++++++++++++++++++++++++-
frontend/src/pages/scripts.jsx | 43 +++++++++++++++++++++++++++++++++++++++++-
2 files changed, 73 insertions(+), 2 deletions(-)
```

- `frontend/src/pages/cards.jsx`
  - `CardEditModal` 新增 `onDelete` prop,新增 `doDelete` 处理函数
  - 右栏底部新增「删除」链接(非新建态才显示)
- `frontend/src/pages/scripts.jsx`
  - NPC `cardDefinition` 的 `act` section 内联删除按钮(带 confirm + toast + 列表重载 + 事件派发)
  - `CardEditModal` 实例把 `onDelete` 接到 `scriptDelete` + 列表重载 + `rpg-scripts-updated` 事件

## 检查清单

- [x] 干跑过 esbuild 语法检查,无报错
- [x] 浏览器实测:删除多余卡后列表从 4 → 0
- [x] 沿用现有 i18n 键,zh-CN / en 都已就绪
- [x] 后端无需改动(端点早已存在)
- [x] 新建态不显示删除按钮(避免给空 id 误删)
- [x] 删前弹 `window.__confirm` 危险确认