### PR TITLE
fix(models): local 模式下模型选择器正确显示用户 BYOK 凭证

### DIFF
--- a/rpg/app.py
+++ b/rpg/app.py
@@ -1112,25 +1112,32 @@ def _redact_catalog(catalog: dict[str, Any], is_admin: bool, user_id: int | None
     import model_probe
     from model_registry import normalize_api_id
     # require_auth() 现已 mode-aware(server 模式 → True),统一按 per-user 账号 key 算 has_credential;
-    # 本地匿名模式 → False → 回退服务器 env/SA 存在性(单用户本机本就该看到服务器凭证)。
+    # 注意:不论 require_auth 与否,只要能解析出 user_id 就按用户 BYOK 算。
+    # 旧版 "if require_auth" 守卫会让 local 模式 + api_user=user 1 走 else(env/SA),
+    # 而 env/SA 在 local 模式几乎都是空的 → has_credential 全部 false。
     from core.config import require_auth as _require_auth
     result = copy.deepcopy(catalog)
     require_auth = _require_auth()
-    cred_ids = _user_credentialed_api_ids(user_id) if require_auth else set()
+    cred_ids = _user_credentialed_api_ids(user_id) if user_id is not None else set()
     for api in result.get("apis", []):
-        if require_auth:
+        if user_id is not None:
             api["has_credential"] = normalize_api_id(api.get("id")) in cred_ids
-        else:
+        elif not require_auth:
+            # 完全匿名 + local 模式(库也无用户):回退服务器 env/SA
             api["has_credential"] = model_probe._credential_present(api)
+        else:
+            api["has_credential"] = False
         if not is_admin:
             api.pop("credential_ref", None)
             api.pop("credential_env", None)
             api.pop("base_url", None)
     # per-user 默认模型:全局 catalog.selected 可能指向用户没配 key 的 provider(默认是
     # anthropic/claude-opus-4-7,而用户只配了 deepseek/vertex)→ 刷新后 UI 会一直显示这个
-    # 用不了的模型。这里在 server 模式把 selected 校正成「用户第一个有凭证的 provider+首模型」,
-    # 让 catalog.selected 始终是用户能用的;用户已自己选过的有效模型不受影响(其 api 在 cred_ids 内)。
-    if require_auth:
+    # 用不了的模型。这里在能解析出 user_id 时把 selected 校正成「用户第一个有凭证的
+    # provider+首模型」,让 catalog.selected 始终是用户能用的;用户已自己选过的有效
+    # 模型不受影响(其 api 在 cred_ids 内)。
+    # local 模式 + 无 user_id 时不动 selected,保持"服务器级默认"的语义。
+    if user_id is not None:
         sel = result.get("selected") or {}
         if normalize_api_id(sel.get("api_id")) not in cred_ids:
             for api in result.get("apis", []):


### PR DESCRIPTION
问题: local 部署模式 + 用户配过 BYOK 凭证时,模型选择器显示'没有可用模型'。

根因: _redact_catalog() 在 local 模式 require_auth=False,走 env/SA 检查, 完全忽略用户在数据库配置的 BYOK 凭证,导致 has_credential 全部为 false。

修复: cred_ids / has_credential 判断改用 user_id is not None 替代 require_auth