### PR TITLE
fix(scripts): 修复 SharingModeSelector 在 commit.id 为数字时崩溃

### DIFF
--- a/frontend/src/pages/scripts.jsx
+++ b/frontend/src/pages/scripts.jsx
@@ -447,9 +447,9 @@ function SharingModeSelector({ script, currentUserId, onChanged }) {
 
   const commitOptions = commits.map(c => ({
     value: c.id,
-    label: `${(c.id || '').slice(0, 8)} · ${c.message || c.kind || ''}`,
+    label: `${String(c.id || '').slice(0, 8)} · ${c.message || c.kind || ''}`,
   }));
-  const selectedCommitOpt = commitOptions.find(o => o.value === pinCommitId) || (pinCommitId ? { value: pinCommitId, label: pinCommitId.slice(0, 8) } : null);
+  const selectedCommitOpt = commitOptions.find(o => o.value === pinCommitId) || (pinCommitId ? { value: pinCommitId, label: String(pinCommitId).slice(0, 8) } : null);
 
   return (
     <CSSpaceBetween size="xs">


### PR DESCRIPTION
使用 String() 包装 c.id 和 pinCommitId,确保调用 .slice() 时是字符串。 仅 owner 访问自己有 commit 的剧本时触发。