### PR TITLE
fix(mobile): 适配 pending question 的 question/options 新数据形态

### DIFF
--- a/frontend/src/mobile/game/MobileGame.jsx
+++ b/frontend/src/mobile/game/MobileGame.jsx
@@ -505,17 +505,25 @@ export function MobileGame(gc) {
                 </div>
               )}
               {pendCount > 0 && <div className="cb-head"><Icon name="warn" size={13} /> 待确认 · {pendCount}</div>}
-              {(pendingQuestions || []).map((q) => (
-                <div key={q.id} className="cb-q">
-                  <div className="cb-q-row"><span className="cb-tag gm">GM 询问</span><span className="cb-q-text">{q.text || q.question}</span></div>
-                  <div className="cb-choices">
-                    {(q.choices || []).map((c, i) => (
-                      <button key={i} className={'cb-choice' + (i === 0 ? ' primary' : '')} onClick={() => onAnswerQuestion(q, c)}>{c}</button>
-                    ))}
-                    <button className="cb-choice" onClick={() => onDismissConfirm(q)}>忽略</button>
+              {(pendingQuestions || []).map((q) => {
+                // 兼容新旧数据形态:question/text 取一,options/choices 取一
+                const qText = q.question || q.text;
+                const qOpts = q.options || q.choices;
+                return (
+                  <div key={q.id} className="cb-q">
+                    <div className="cb-q-row"><span className="cb-tag gm">GM 询问</span><span className="cb-q-text">{qText}</span></div>
+                    <div className="cb-choices">
+                      {(qOpts || []).map((c, i) => {
+                        const label = typeof c === 'string' ? c : (c.text || c.label || c.id || JSON.stringify(c));
+                        return (
+                          <button key={i} className={'cb-choice' + (i === 0 ? ' primary' : '')} onClick={() => onAnswerQuestion(q, c)}>{label}</button>
+                        );
+                      })}
+                      <button className="cb-choice" onClick={() => onDismissConfirm(q)}>忽略</button>
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
               {(pendingWrites || []).map((wr) => (
                 <div key={wr.id} className={'cb-w ' + (wr.risk || 'low')}>
                   <div className="cb-w-row"><span className={'cb-tag risk ' + (wr.risk || 'low')}><Icon name="warn" size={11} /> 写入</span><span className="cb-field mono">{wr.field || wr.path || ''}</span></div>


### PR DESCRIPTION
## 问题描述
移动端游戏控制台"待确认"条(顶部 confirmbar)在 GM 输出选项
时只渲染了一个"忽略"按钮,选项按钮完全消失;桌面端同一份
数据下选项正常显示,移动端用户实际上无法选择 GM 提供的回应。

## 根因分析
后端从 `task46` 起将 pending question 的数据形态从
```
{ text: "...", choices: [...] }
```
改为
```
{ question: "...", options: [...] }
```
(见 `rpg/state/_mixins/pending.py`)。

`frontend/src/game-composer.jsx`(桌面端)已经做了双向兼容:
```js
const qText = it.data?.question || it.data?.text;
const opts  = it.data?.options  || it.data?.choices;
```
但 `frontend/src/mobile/game/MobileGame.jsx`(移动端)漏写
了对应兼容,confirmbar 直接读 `q.text` 和 `q.choices`,全部为
`undefined`,只剩"忽略"按钮可点。

## Before
```
[待确认 · 1]
GM 询问 你对红的表态做何回应?
[忽略]
```

## After
```
[待确认 · 1]
GM 询问 你对红的表态做何回应?
[赞许并安抚她...] [保持冷淡...] [询问她...]
[忽略]
```

## 修改
- `frontend/src/mobile/game/MobileGame.jsx`:
  - 提取 `qText = q.question || q.text`
  - 提取 `qOpts = q.options || q.choices`
  - 对每个 option 元素兼容 `string` 与 `{id, text}` 两种形态

## 影响
- 单文件改动,+18 / -10
- 不影响桌面端、不影响后端、不影响数据契约
- 向后兼容旧字段,旧数据仍可正确渲染