### PR TITLE
fix(mobile): resolve empty model list in game console bottom sheet

### DIFF
--- a/frontend/src/mobile/game/MobileGame.jsx
+++ b/frontend/src/mobile/game/MobileGame.jsx
@@ -289,8 +289,25 @@ function ModelSheetBody({ gc, onClose }) {
     (async () => {
       try {
         const r = await window.api.models.list();
-        const list = Array.isArray(r) ? r : (r?.models || r?.items || []);
-        if (!dead) setModels(list);
+        // /api/models 返回 {ok, models:{apis:[...], selected:{...}}}
+        const apis = (r && r.models && Array.isArray(r.models.apis))
+          ? r.models.apis
+          : (Array.isArray(r?.apis) ? r.apis : []);
+        const flat = [];
+        for (const api of apis) {
+          if (api.enabled === false) continue;
+          if (api.has_credential === false) continue;
+          const apiId = api.id || api.api_id || '';
+          const mods = Array.isArray(api.models) ? api.models : [];
+          for (const m of mods) {
+            if (m.enabled === false) continue;
+            // 跳过 embedding 等非聊天模型
+            const caps = Array.isArray(m.capabilities) ? m.capabilities : [];
+            if (caps.includes('embedding')) continue;
+            flat.push({ ...m, api_id: apiId, label: m.display_name || m.real_name || m.id });
+          }
+        }
+        if (!dead) setModels(flat);
       } catch (_) { if (!dead) setModels([]); }
     })();
     return () => { dead = true; };


### PR DESCRIPTION
### Description | 描述
修复了在手机模式（Mobile Game Console）下，底部工具栏模型选择面板展示为“没有可用模型”的问题。

### Cause | 原因分析
在 `MobileGame.jsx` 的 `ModelSheetBody` 组件中：
- 接口 `window.api.models.list()` 返回的 `r.models` 是一个形如 `{ apis: [...] }` 的对象，而不是数组。
- 旧代码使用 `const models = Array.isArray(r) ? r : (r?.models || r?.items || [])` 取得该对象。
- 由于对象没有 `.length` 属性，会导致 `!models.length` 判定为真，直接展示“没有可用模型”占位符。

### Changes | 修改内容
重构了 `ModelSheetBody` 中的模型列表解析与扁平化逻辑（与 PC 端 `ModelPicker` / `game-composer` 保持一致）：
1. 提取并遍历 `apis` 列表，过滤未启用 (`enabled === false`) 或无凭证 (`has_credential === false`) 的 API 服务商。
2. 提取并遍历底层的 `models`，过滤未启用或用途为 `embedding` 的模型。
3. 转换为扁平数组并附加 `api_id`，正确载入到 state 中。

### Verification | 验证
- 底部模型选择 Chip 已能正常展示当前选择的模型名（例如 `"豆包 Seed 2.0 Pro (ppio)"`）。
- 点击 Chip 弹出底部 Sheet，能正确显示所有已配置服务商下的所有可用模型列表，且支持点击切换。