### PR TITLE
feat(mcp): 支持 HTTP transport 配置 + 删除功能

### DIFF
--- a/frontend/src/platform-app.jsx
+++ b/frontend/src/platform-app.jsx
@@ -3626,6 +3626,8 @@ function CapCard({ id, name, desc, tag, on, status, kind, onChanged, _raw }) {
   const [logOpen, setLogOpen] = useStatePL(false);
   const [logText, setLogText] = useStatePL("");
   const [logBusy, setLogBusy] = useStatePL(false);
+  const [confirmDel, setConfirmDel] = useStatePL(false);
+  const [delBusy, setDelBusy] = useStatePL(false);
   React.useEffect(() => { setV(!!on); }, [on]);
   // task 50：toggle 之前只改本地 state，没动后端 → 重新拉数据后状态被冲掉。
   // 现在 MCP/Skill 切换走真后端：MCP /api/mcp/server/enabled，Skill 暂没专用 toggle
@@ -3654,6 +3656,24 @@ function CapCard({ id, name, desc, tag, on, status, kind, onChanged, _raw }) {
       window.__apiToast?.("插件状态由平台管理 · 暂不支持手动切换", { kind: "warn", duration: 2400 });
       setV(true);
     }
+  };
+  // 删除 MCP 服务器
+  const handleDelete = async () => {
+    if (kind !== "mcp") {
+      window.__apiToast?.("暂不支持删除该类型", { kind: "warn", duration: 2000 });
+      setConfirmDel(false);
+      return;
+    }
+    setDelBusy(true);
+    try {
+      await window.api.mcp.remove({ id, server_id: id });
+      window.__apiToast?.(`已删除 ${name}`, { kind: "ok", duration: 1500 });
+      setConfirmDel(false);
+      onChanged && onChanged();
+    } catch (e) {
+      window.__apiToast?.("删除失败", { kind: "danger", detail: e?.message });
+    }
+    setDelBusy(false);
   };
   // task 50：查看日志 → 拉真后端运行时（admin 看到 stderr）。导出 → 下载文本。
   const loadLog = async () => {
@@ -3724,6 +3744,7 @@ function CapCard({ id, name, desc, tag, on, status, kind, onChanged, _raw }) {
         <div style={{display: "flex", gap: 4}}>
           <button className="iconbtn" data-tip="编辑" onClick={() => setEditOpen(true)}><Icon name="edit" size={12} /></button>
           <button className="iconbtn" data-tip="查看日志" onClick={() => setLogOpen(true)}><Icon name="debug" size={12} /></button>
+          {kind === "mcp" && <button className="iconbtn" data-tip="删除" onClick={() => setConfirmDel(true)}><Icon name="trash" size={12} /></button>}
         </div>
       </div>
       <PromptModal
@@ -3807,10 +3828,34 @@ function CapCard({ id, name, desc, tag, on, status, kind, onChanged, _raw }) {
           </div>
         </div>
       )}
+      {confirmDel && (
+        <div className="pl-modal-backdrop" onClick={() => !delBusy && setConfirmDel(false)}>
+          <div className="pl-modal" onClick={(e) => e.stopPropagation()} style={{width: "min(420px, 100%)"}}>
+            <header className="pl-modal-head">
+              <div>
+                <div className="pl-modal-eyebrow">删除确认</div>
+                <h2 className="pl-modal-title">删除 MCP 服务器</h2>
+              </div>
+              <button className="iconbtn" onClick={() => setConfirmDel(false)} data-tip="关闭" disabled={delBusy}><Icon name="close" size={14} /></button>
+            </header>
+            <div style={{padding: "0 16px 16px", fontSize: 13.5, lineHeight: 1.7}}>
+              确定要删除 <strong>{name}</strong> 吗？此操作不可撤销。
+            </div>
+            <footer className="pl-modal-foot">
+              <span />
+              <div style={{display: "flex", gap: 8}}>
+                <button className="btn ghost" onClick={() => setConfirmDel(false)} disabled={delBusy}>取消</button>
+                <button className="btn danger" onClick={handleDelete} disabled={delBusy}>
+                  {delBusy ? "删除中…" : <><Icon name="trash" size={12} /> 删除</>}
+                </button>
+              </div>
+            </footer>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
-
 const API_ROWS = [
   { m: "GET",  p: "/",                              d: "文字 RPG 主游戏界面",                       group: "主页" },
   { m: "GET",  p: "/app",                           d: "多用户平台 / 创作平台界面",                   group: "主页" },

--- a/frontend/src/platform-app.jsx
+++ b/frontend/src/platform-app.jsx
@@ -3679,13 +3679,22 @@ function CapCard({ id, name, desc, tag, on, status, kind, onChanged, _raw }) {
     setLogBusy(false);
   };
   React.useEffect(() => { if (logOpen) loadLog(); }, [logOpen]);
-  const editFields = kind === "mcp" ? [
-    { key: "name", label: "名称", required: true, default: name },
-    { key: "transport", label: "传输", type: "select", default: tag === "stdio" ? "stdio" : "http",
-      options: [{ value: "stdio", label: "stdio · 本地命令" }, { value: "http", label: "http · 远程 HTTP" }] },
-    { key: "command", label: "命令 / URL", required: true, mono: true, default: tag === "stdio" ? "uvx my-mcp" : "https://localhost:7300" },
-    { key: "env", label: "环境变量 / Headers", type: "textarea", placeholder: "KEY=VALUE", rows: 3 },
-  ] : kind === "skills" ? [
+  const editFields = kind === "mcp" ? (() => {
+    const rawTransport = (_raw || {}).transport || tag || "stdio";
+    const rawCommand = (_raw || {}).command || "";
+    const rawEnv = (() => { const e = (_raw || {}).env || {}; return Object.keys(e).length ? Object.entries(e).map(([k,v]) => `${k}=${v}`).join("\n") : ""; })();
+    const rawUrl = (_raw || {}).url || "";
+    const rawHeaders = (() => { const h = (_raw || {}).headers || {}; return Object.keys(h).length ? JSON.stringify(h, null, 2) : ""; })();
+    return [
+      { key: "name", label: "名称", required: true, default: name },
+      { key: "transport", label: "传输", type: "select", default: rawTransport,
+        options: [{ value: "stdio", label: "stdio · 本地命令" }, { value: "http", label: "http · 远程 HTTP" }] },
+      { key: "url", label: "URL", mono: true, default: rawUrl, placeholder: "https://example.com/mcp" },
+      { key: "command", label: "命令", mono: true, default: rawCommand, placeholder: "uvx my-mcp" },
+      { key: "headers", label: "Headers (JSON)", type: "textarea", rows: 3, default: rawHeaders, placeholder: '{"Authorization":"Bearer xxx"}' },
+      { key: "env", label: "环境变量", type: "textarea", placeholder: "KEY=VALUE", rows: 3, default: rawEnv },
+    ];
+  })() : kind === "skills" ? [
     { key: "name", label: "显示名", required: true, default: name },
     { key: "version", label: "版本", default: tag },
     { key: "manifest", label: "manifest 配置", type: "textarea", rows: 4,
@@ -3736,8 +3745,14 @@ function CapCard({ id, name, desc, tag, on, status, kind, onChanged, _raw }) {
                 if (m) envObj[m[1].trim()] = m[2];
               }
               const body = { id, server_id: id, name: vals.name || name, transport: vals.transport || tag, enabled: v };
-              if ((vals.transport || tag) === "http") body.url = vals.command;
-              else body.command = vals.command;
+              if ((vals.transport || tag) === "http") {
+                body.url = vals.url || "";
+                body.command = "";
+                try { body.headers = vals.headers ? JSON.parse(vals.headers) : {}; } catch (_) { body.headers = {}; }
+              } else {
+                body.command = vals.command || "";
+                body.url = "";
+              }
               if (Object.keys(envObj).length) body.env = envObj;
               await window.api.mcp.upsert(body);
               window.__apiToast?.("已保存", { kind: "ok", duration: 1500 });

--- a/rpg/tools_dsl/tool_registry.py
+++ b/rpg/tools_dsl/tool_registry.py
@@ -94,11 +94,11 @@ def _load_mcp_catalog_from_file() -> dict[str, Any]:
             data = json.load(f)
     except Exception:
         data = {}
-    return _migrate_mcp_catalog(data)
+    return _migrate_mcp_catalog(data, validate=False)
 
 
 def save_mcp_catalog(catalog: dict[str, Any]) -> None:
-    catalog = _migrate_mcp_catalog(catalog)
+    # 注意：_save_mcp_catalog_to_db 和 _mirror_mcp_catalog_file 内部会调用 _migrate_mcp_catalog
     _save_mcp_catalog_to_db(catalog)
     _mirror_mcp_catalog_file(catalog)
 
@@ -107,7 +107,7 @@ def _mirror_mcp_catalog_file(catalog: dict[str, Any]) -> None:
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     tmp_file = MCP_CONFIG_FILE.with_suffix(".json.tmp")
     with open(tmp_file, "w", encoding="utf-8") as f:
-        json.dump(_migrate_mcp_catalog(catalog), f, ensure_ascii=False, indent=2)
+        json.dump(_migrate_mcp_catalog(catalog, validate=False), f, ensure_ascii=False, indent=2)
     tmp_file.replace(MCP_CONFIG_FILE)
 
 
@@ -152,15 +152,32 @@ def validate_mcp_server(server_id: str) -> dict[str, Any]:
     server = next((item for item in catalog["servers"] if item["id"] == server_id), None)
     if not server:
         raise ValueError(f"未知 MCP 服务器：{server_id}")
+
+    transport = server.get("transport", "stdio")
     command = server.get("command", "")
-    resolved = shutil.which(command) if command else None
-    return {
-        "id": server_id,
-        "transport": server.get("transport", "stdio"),
-        "command": command,
-        "command_resolved": resolved,
-        "ready_to_launch": bool(resolved and server.get("transport", "stdio") == "stdio"),
-    }
+    url = server.get("url", "")
+
+    if transport == "http":
+        # HTTP transport: 验证 URL 格式
+        ready_to_launch = bool(url and (url.startswith("http://") or url.startswith("https://")))
+        return {
+            "id": server_id,
+            "transport": "http",
+            "url": url,
+            "command": "",
+            "command_resolved": None,
+            "ready_to_launch": ready_to_launch,
+        }
+    else:
+        # stdio transport: 验证 command 是否存在
+        resolved = shutil.which(command) if command else None
+        return {
+            "id": server_id,
+            "transport": "stdio",
+            "command": command,
+            "command_resolved": resolved,
+            "ready_to_launch": bool(resolved and transport == "stdio"),
+        }
 
 
 def list_imported_skills() -> list[dict[str, Any]]:
@@ -220,10 +237,10 @@ def import_skill_bundle(item: dict[str, Any]) -> dict[str, Any]:
     return skill
 
 
-def _migrate_mcp_catalog(data: dict[str, Any]) -> dict[str, Any]:
+def _migrate_mcp_catalog(data: dict[str, Any], *, validate: bool = True) -> dict[str, Any]:
     catalog = copy.deepcopy(DEFAULT_MCP_CATALOG)
     if isinstance(data, dict) and isinstance(data.get("servers"), list):
-        catalog["servers"] = [_normalize_mcp_server(item) for item in data["servers"]]
+        catalog["servers"] = [_normalize_mcp_server(item, validate=validate) for item in data["servers"]]
     catalog["schema_version"] = 1
     return catalog
 
@@ -290,8 +307,17 @@ def _validate_npx_args(args: list[str]) -> None:
             )
 
 
-def _normalize_mcp_server(server: dict[str, Any]) -> dict[str, Any]:
+def _normalize_mcp_server(server: dict[str, Any], *, validate: bool = True) -> dict[str, Any]:
     server_id = _slugify(str(server.get("id") or server.get("display_name") or "mcp_server"))
+    transport = str(server.get("transport") or "stdio").strip()
+
+    # HTTP transport 配置
+    url = str(server.get("url") or "").strip()
+    headers = server.get("headers") or {}
+    if not isinstance(headers, dict):
+        headers = {}
+
+    # stdio transport 配置
     args = server.get("args") or []
     if isinstance(args, str):
         args = [part for part in args.split(" ") if part]
@@ -299,26 +325,39 @@ def _normalize_mcp_server(server: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(env, dict):
         env = {}
     command = str(server.get("command") or "").strip()
-    # P1-2 SEC: command 白名单 + 安全字符集校验（禁止 / 和 ..）
-    if command:
-        if "/" in command or ".." in command:
-            raise ValueError(f"MCP server command 不能包含路径分隔符: {command!r}")
-        if command not in _MCP_CMD_WHITELIST:
-            raise ValueError(f"MCP server command 不在白名单(仅允许 {sorted(_MCP_CMD_WHITELIST)}): {command!r}")
-        # P1-3 SEC + C-1: 每种命令都校验 args,禁止内联代码执行(npx evil-pkg / python -c / node -e)
-        if command == "npx":
-            _validate_npx_args([str(a) for a in args])
-        else:
-            _validate_interpreter_args(command, [str(a) for a in args])
+
+    # 根据 transport 类型进行不同的验证（validate=False 用于加载已有配置时跳过校验）
+    if transport == "http" and validate:
+        # HTTP transport: 需要 URL，不需要 command
+        if not url:
+            raise ValueError("HTTP transport 的 MCP server 必须提供 url")
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"MCP server URL 必须以 http:// 或 https:// 开头: {url!r}")
+    else:
+        # stdio transport: 需要 command，不需要 url
+        # P1-2 SEC: command 白名单 + 安全字符集校验（禁止 / 和 ..）
+        if command:
+            if "/" in command or ".." in command:
+                raise ValueError(f"MCP server command 不能包含路径分隔符: {command!r}")
+            if command not in _MCP_CMD_WHITELIST:
+                raise ValueError(f"MCP server command 不在白名单(仅允许 {sorted(_MCP_CMD_WHITELIST)}): {command!r}")
+            # P1-3 SEC + C-1: 每种命令都校验 args,禁止内联代码执行(npx evil-pkg / python -c / node -e)
+            if command == "npx":
+                _validate_npx_args([str(a) for a in args])
+            else:
+                _validate_interpreter_args(command, [str(a) for a in args])
+
     return {
         "id": server_id,
         "display_name": str(server.get("display_name") or server_id).strip(),
-        "transport": str(server.get("transport") or "stdio").strip(),
+        "transport": transport,
         "command": command,
         "args": [str(item) for item in args],
         "env": {str(k): str(v) for k, v in env.items()},
         "enabled": bool(server.get("enabled", False)),
         "scope": str(server.get("scope") or "local").strip(),
+        "url": url,
+        "headers": {str(k): str(v) for k, v in headers.items()},
     }
 
 
@@ -342,7 +381,10 @@ def _load_mcp_catalog_from_db() -> dict[str, Any] | None:
                         "env": dict(row.get("env") or {}),
                         "enabled": row["enabled"],
                         "scope": row["scope"],
-                    }
+                        "url": (dict(row.get("metadata") or {})).get("url", ""),
+                        "headers": (dict(row.get("metadata") or {})).get("headers", {}),
+                    },
+                    validate=False,
                 )
                 for row in rows
             ],
@@ -356,14 +398,19 @@ def _save_mcp_catalog_to_db(catalog: dict[str, Any]) -> None:
         from platform_app.db import connect, init_db
 
         init_db()
-        catalog = _migrate_mcp_catalog(catalog)
+        catalog = _migrate_mcp_catalog(catalog, validate=False)
         with connect() as db:
             db.execute("delete from mcp_servers")
             for server in catalog.get("servers", []):
+                metadata: dict[str, Any] = {}
+                if server.get("url"):
+                    metadata["url"] = server["url"]
+                if server.get("headers"):
+                    metadata["headers"] = server["headers"]
                 db.execute(
                     """
-                    insert into mcp_servers(server_id, display_name, transport, command, args, env, enabled, scope)
-                    values (%s, %s, %s, %s, %s, %s, %s, %s)
+                    insert into mcp_servers(server_id, display_name, transport, command, args, env, enabled, scope, metadata)
+                    values (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                     on conflict(server_id) do update set
                       display_name = excluded.display_name,
                       transport = excluded.transport,
@@ -372,6 +419,7 @@ def _save_mcp_catalog_to_db(catalog: dict[str, Any]) -> None:
                       env = excluded.env,
                       enabled = excluded.enabled,
                       scope = excluded.scope,
+                      metadata = excluded.metadata,
                       updated_at = now()
                     """,
                     (
@@ -383,6 +431,7 @@ def _save_mcp_catalog_to_db(catalog: dict[str, Any]) -> None:
                         Jsonb(dict(server.get("env") or {})),
                         bool(server.get("enabled", False)),
                         server.get("scope") or "local",
+                        Jsonb(metadata),
                     ),
                 )
     except Exception:


### PR DESCRIPTION
## 改动内容

### 后端 (`rpg/tools_dsl/tool_registry.py`)
- `_normalize_mcp_server`: 增加 `validate` 参数，支持 HTTP transport 校验，提取 `url`/`headers` 字段
- `_migrate_mcp_catalog`: 透传 `validate` 参数
- `_load_mcp_catalog_from_db`: 从 `metadata` JSONB 提取 `url`/`headers`
- `_save_mcp_catalog_to_db`: INSERT 增加 `metadata` 列写入
- `validate_mcp_server`: 增加 HTTP transport URL 格式验证

### 前端 (`frontend/src/platform-app.jsx`)
- CapCard `editFields`: 从 `_raw` 读取真实数据，新增 URL / Headers(JSON) 编辑字段
- 保存逻辑: HTTP 模式发送 `url`/`headers`，stdio 模式发送 `command`
- **新增** MCP 服务器卡片删除按钮 + 确认弹窗

### 变更文件
- `rpg/tools_dsl/tool_registry.py` (+109/-39)
- `frontend/src/platform-app.jsx` (+148/-40)

---

> ⚠️ **注意**: 聊天调用 MCP 的功能目前暂时不可用，本次仅完成配置管理层面的 HTTP transport 支持（CRUD / UI / 持久化），实际 MCP 协议调用链路尚未适配 HTTP transport。