### PR TITLE
feat: 首次进入或刷新页面时自动滚动到最底部

### DIFF
--- a/frontend/src/game-app.jsx
+++ b/frontend/src/game-app.jsx
@@ -998,6 +998,7 @@ function ChatArea({ history, runState, runStyle, narrativeFont, narrativeSize, h
 
   // task 133: Claude 风格自动滚动 — 用户上滚后停止跟随 + 回到底部按钮
   const isAtBottomRef = useRefA(true);
+  const isFirstLoadRef = useRefA(true);
   const [showJumpBtn, setShowJumpBtn] = useStateA(false);
   // 用户滚动时检测是否离开底部
   useEffectA(() => {
@@ -1012,14 +1013,17 @@ function ChatArea({ history, runState, runStyle, narrativeFont, narrativeSize, h
     el.addEventListener("scroll", onScroll, { passive: true });
     return () => el.removeEventListener("scroll", onScroll);
   }, []);
-  // 新内容时的滚动策略:① 自己刚发消息(末条=玩家)→ 强制滚到底;② 否则双守卫——
+  // 新内容时的滚动策略:① 第一次进入或刷新页面时，强制滚动到最底部; ② 自己刚发消息(末条=玩家)→ 强制滚到底; ③ 否则双守卫——
   // 用户已上滚(isAtBottom=false) 或 实时距底 >360px(防 ref 时序滞后/iOS 节流)→ 绝不跟随。
   // 这样 GM 输出(含输出完成 running→false)在用户看上文时不会被硬拽回底部。
   useEffectA(() => {
     const el = ref.current;
     if (!el) return;
     const last = history && history[history.length - 1];
-    if (last && last.role === "user") {
+    if (visible.length > 0 && isFirstLoadRef.current) {
+      isFirstLoadRef.current = false;
+      isAtBottomRef.current = true;
+    } else if (last && last.role === "user") {
       isAtBottomRef.current = true;  // 自己发的:跟到底
     } else if (!isAtBottomRef.current || (el.scrollHeight - el.scrollTop - el.clientHeight) > 360) {
       return;  // 用户在看上文 → 不强制跟随

--- a/frontend/src/mobile/game/MobileGame.jsx
+++ b/frontend/src/mobile/game/MobileGame.jsx
@@ -360,6 +360,7 @@ export function MobileGame(gc) {
   const anyOverlay = leftOpen || rightOpen || !!sheet;
 
   const atBottomRef = useRef(true);
+  const isFirstLoadRef = useRef(true);
   const scrollBottom = useCallback((smooth) => {
     const el = chatRef.current; if (!el) return;
     requestAnimationFrame(() => el.scrollTo({ top: el.scrollHeight, behavior: smooth ? 'smooth' : 'auto' }));
@@ -372,11 +373,14 @@ export function MobileGame(gc) {
     return () => el.removeEventListener('scroll', onScroll);
   }, []);
   useEffect(() => { scrollBottom(false); }, []);  // 挂载滚底
-  // ① 自己刚发(末条=玩家)→ 滚底;② 否则双守卫:已上滚 或 实时距底>360 → 不跟随(GM 输出完成不拽回)
+  // ① 第一次进入或刷新页面时，强制滚动到最底部; ② 自己刚发(末条=玩家)→ 滚底; ③ 否则双守卫:已上滚 或 实时距底>360 → 不跟随(GM 输出完成不拽回)
   useEffect(() => {
     const el = chatRef.current; if (!el) return;
     const last = history && history[history.length - 1];
-    if (last && last.role === 'user') { atBottomRef.current = true; }
+    if (history.length > 0 && isFirstLoadRef.current) {
+      isFirstLoadRef.current = false;
+      atBottomRef.current = true;
+    } else if (last && last.role === 'user') { atBottomRef.current = true; }
     else if (!atBottomRef.current || (el.scrollHeight - el.scrollTop - el.clientHeight) > 360) { return; }
     scrollBottom(true);
   }, [history.length, running]);

--- a/frontend/src/mobile/pages/MobileTavern.jsx
+++ b/frontend/src/mobile/pages/MobileTavern.jsx
@@ -634,6 +634,7 @@ function ChatView({
   const threadRef = useRef(null);
   const taRef = useRef(null);
   const atBottomRef = useRef(true);
+  const isFirstLoadRef = useRef(true);
   const [showJump, setShowJump] = useState(false);
 
   const charName = (character && character.name) || (activeChat && activeChat.character_name) || '角色';
@@ -651,12 +652,15 @@ function ChatView({
     return () => el.removeEventListener('scroll', onScroll);
   }, []);
 
-  // ① 自己刚发(末条=玩家)→ 滚到底;② 否则双守卫:已上滚 或 实时距底>360 → 不跟随(输出完成不拽回)
+  // ① 第一次进入或刷新页面时，强制滚动到最底部; ② 自己刚发(末条=玩家)→ 滚到底; ③ 否则双守卫:已上滚 或 实时距底>360 → 不跟随(输出完成不拽回)
   useEffect(() => {
     const el = threadRef.current;
     if (!el) return;
     const last = history && history[history.length - 1];
-    if (last && last.role === 'user') {
+    if (history.length > 0 && isFirstLoadRef.current) {
+      isFirstLoadRef.current = false;
+      atBottomRef.current = true;
+    } else if (last && last.role === 'user') {
       atBottomRef.current = true;
     } else if (!atBottomRef.current || (el.scrollHeight - el.scrollTop - el.clientHeight) > 360) {
       return;

--- a/frontend/src/tavern-app.jsx
+++ b/frontend/src/tavern-app.jsx
@@ -346,6 +346,7 @@ export function TavernThinkingBlock({ text, thinking }) {
 export function TavernChatArea({ history, running, saveId, charName, charInitial, charAvatar, personaName, hasError, errorMsg, onRetry, lastMeta, elapsedLabel }) {
   const ref = useRef(null);
   const atBottomRef = useRef(true);
+  const isFirstLoadRef = useRef(true);
   const [showJump, setShowJump] = useState(false);
 
   // 内嵌聊天图片:最后一条助手消息绝对索引 + 图片按消息分发(复用游戏端 hook)
@@ -368,12 +369,15 @@ export function TavernChatArea({ history, running, saveId, charName, charInitial
     return () => el.removeEventListener('scroll', onScroll);
   }, []);
 
-  // ① 自己刚发(末条=玩家)→ 滚到底;② 否则双守卫:已上滚 或 实时距底>360 → 不跟随(GM 输出完成不拽回)
+  // ① 第一次进入或刷新页面时，强制滚动到最底部; ② 自己刚发(末条=玩家)→ 滚到底; ③ 否则双守卫:已上滚 或 实时距底>360 → 不跟随(GM 输出完成不拽回)
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
     const last = history && history[history.length - 1];
-    if (last && last.role === 'user') {
+    if (history.length > 0 && isFirstLoadRef.current) {
+      isFirstLoadRef.current = false;
+      atBottomRef.current = true;
+    } else if (last && last.role === 'user') {
       atBottomRef.current = true;
     } else if (!atBottomRef.current || (el.scrollHeight - el.scrollTop - el.clientHeight) > 360) {
       return;


### PR DESCRIPTION
### 🚀 变更背景与原因
此前在桌面端和移动端的游戏控制台、酒馆聊天页面中，首次进入页面或刷新页面时，聊天记录区域无法自动滚动到最底部。

**原因分析：**
各聊天组件的自动滚动逻辑中设计了针对 GM 正在流式输出时的“双守卫避让”机制（即用户已向上滚动，或实时消息距离底部 > 360px 时不强制跟随滚底，避免打扰用户阅读上文）。然而在首屏加载或刷新时，因为历史对话瞬间从无到有载入，导致滚动条未到达底部时内容差值远大于 360px，误触发了该守卫，阻断了初次的自动滚底。

#### 🛠️ 解决方案
在相关聊天组件中引入了首屏加载状态标记 `isFirstLoadRef`：
1. 当首次载入非空的历史对话数据时，绕过防跟随守卫并强制执行一次滚底，确保页面初次加载时能看到最新内容。
2. 首次滚动执行后，将 `isFirstLoadRef` 标记为 `false`，此后继续沿用正常的双守卫避让机制。

#### 📝 涉及文件与修改
- **桌面端游戏控制台聊天区**：`frontend/src/game-app.jsx` 中的 `ChatArea`
- **桌面端酒馆对话区**：`frontend/src/tavern-app.jsx` 中的 `TavernChatArea`
- **移动端酒馆对话区**：`frontend/src/mobile/pages/MobileTavern.jsx` 中的 `ChatView`
- **移动端游戏控制台**：`frontend/src/mobile/game/MobileGame.jsx` 中的 `MobileGame`