### PR TITLE
修复：右侧面板刷新后自动展开的问题

### DIFF
--- a/frontend/src/entries/game-console.jsx
+++ b/frontend/src/entries/game-console.jsx
@@ -436,8 +436,8 @@ function App() {
   const gcPanelDragProps = _panelResize.dragHandleProps;
 
   useEffect(() => {
+    // 宽度不足 180 时自动折叠；但不再自动展开——折叠/展开完全由用户控制
     if (gcPanelW < 180 && !panelCollapsed) setPanelCollapsed(true);
-    else if (gcPanelW >= 180 && panelCollapsed && gcPanelW !== 320) setPanelCollapsed(false);
   }, [gcPanelW]);
   useEffect(() => {
     const bus = window.__capBus || (window.__capBus = new EventTarget());


### PR DESCRIPTION
## 问题

右侧面板的折叠/展开状态在每次页面刷新后会被强制展开，无论用户之前是否手动折叠了面板。

**根因分析：**

[`useEffect`](frontend/src/entries/game-console.jsx) 中的逻辑：
```javascript
if (gcPanelW < 180 && !panelCollapsed) setPanelCollapsed(true);
else if (gcPanelW >= 180 && panelCollapsed && gcPanelW !== 320) setPanelCollapsed(false);
```

当用户拖拽过面板宽度（`gcPanelW !== 320`）时，第二个条件成立，强制将面板展开。

## 修复

移除 `else if` 分支，折叠/展开状态完全由用户控制。宽度不足 180 时仍会自动折叠作为安全保护。

**影响范围：** 仅 [`game-console.jsx`](frontend/src/entries/game-console.jsx)，无其他文件变更。