### PR TITLE
feat(tavern): 酒馆相关功能优化与修复

### DIFF
--- a/frontend/src/mobile/pages/MobileCards.jsx
+++ b/frontend/src/mobile/pages/MobileCards.jsx
@@ -512,14 +512,19 @@ function ImportSheet({ show, onClose, onConfirm }) {
     setParseError('');
     try {
       const obj = JSON.parse(json);
-      const name = obj.name || obj.char_name || obj.data?.name || '(未命名)';
-      const desc = obj.description || obj.data?.description || '暂无简介';
+      // 解包常见的外层包装（如 {"ok":true,"card":{...}}）
+      const inner = obj.card?.data ? obj.card : obj.character?.data ? obj.character : obj;
+      const d = inner.data || {};
+      const name = inner.name || inner.char_name || d.name || '(未命名)';
+      const desc = inner.description || d.description || '暂无简介';
+      const spec = inner.spec || obj.spec;
+      const specVersion = inner.spec_version || obj.spec_version;
       setParsed({
         name,
-        format: obj.spec ? `${obj.spec} · ${obj.spec_version || 'v1'}` : 'JSON',
+        format: spec ? `${spec} · ${specVersion || 'v1'}` : 'JSON',
         description: desc.length > 120 ? desc.slice(0, 120) + '…' : desc,
-        tags: obj.tags || obj.data?.tags || [],
-        first_mes: obj.first_mes || obj.data?.first_mes || '—',
+        tags: inner.tags || d.tags || [],
+        first_mes: inner.first_mes || d.first_mes || '—',
         _jsonString: json,
       });
     } catch (e) {

--- a/frontend/src/pages/cards.jsx
+++ b/frontend/src/pages/cards.jsx
@@ -1287,15 +1287,20 @@ function TavernImportModal({ open, onClose, onConfirm }) {
     setParseError(null);
     try {
       const obj = JSON.parse(json);
-      const name = obj.name || obj.char_name || obj.data?.name || t('cards.detail.unnamed');
-      const desc = obj.description || obj.data?.description || t('cards.import.no_desc');
+      // 解包常见的外层包装（如 {"ok":true,"card":{...}}）
+      const inner = obj.card?.data ? obj.card : obj.character?.data ? obj.character : obj;
+      const d = inner.data || {};
+      const name = inner.name || inner.char_name || d.name || t('cards.detail.unnamed');
+      const desc = inner.description || d.description || t('cards.import.no_desc');
+      const spec = inner.spec || obj.spec;
+      const specVersion = inner.spec_version || obj.spec_version;
       setParsed({
         name,
-        format: obj.spec ? `${obj.spec} · ${obj.spec_version || "v1"}` : "SillyTavern · JSON",
+        format: spec ? `${spec} · ${specVersion || "v1"}` : "SillyTavern · JSON",
         description: desc.length > 160 ? desc.slice(0, 160) + "…" : desc,
-        tags: obj.tags || obj.data?.tags || [],
-        first_mes: obj.first_mes || obj.data?.first_mes || "—",
-        example_count: (obj.mes_example || obj.data?.mes_example || "").split(/<START>/).filter(Boolean).length,
+        tags: inner.tags || d.tags || [],
+        first_mes: inner.first_mes || d.first_mes || "—",
+        example_count: (inner.mes_example || d.mes_example || "").split(/<START>/).filter(Boolean).length,
         _jsonString: json,
       });
     } catch (e) {

--- a/frontend/src/pages/tavern-platform.css
+++ b/frontend/src/pages/tavern-platform.css
@@ -122,6 +122,7 @@
   padding: 0 16px;
   border-bottom: 1px solid var(--line);
   background: color-mix(in srgb, var(--panel) 60%, transparent);
+  overflow: hidden;
 }
 .tvp-chat-title {
   display: inline-flex;
@@ -145,6 +146,7 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  overflow-x: hidden;
   position: relative;
   /* #2 工具调用展开/折叠时历史上移修复:关闭浏览器滚动锚定 —— 否则展开 ToolCallBlock 使其下方
      内容变高时,浏览器锚到下方元素并增大 scrollTop,把上方历史顶上去。关掉后 scrollTop 不变 →
@@ -161,9 +163,10 @@
 }
 /* 酒馆输入框:默认 1 行,随输入增高,最多 ~5 行后内部滚动(覆盖 writing 模式的 88px 起始高度)。
    发送清空后由 Composer 的 reset effect 把高度收回 1 行。 */
-.tvp-foot .gc-composer.writing .gc-textarea {
+.tvp-root .tvp-foot .gc-composer.writing .gc-textarea {
   min-height: 36px;   /* 1 行(serif 15.5px/1.78 + padding) */
   max-height: 150px;  /* ~5 行,超出滚动(JS 把 height 设到 scrollHeight,这里 max-height 封顶) */
+  padding: 8px 16px;  /* 上下对称,文字垂直居中 */
 }
 
 /* ── cards 视图 ───────────────────────────────────────────────── */

--- a/frontend/src/pages/tavern.jsx
+++ b/frontend/src/pages/tavern.jsx
@@ -601,6 +601,13 @@ export default function TavernPage() {
     startRun(t2);
   }, [running, lastPlayerText, history, startRun]);
 
+  // 监听 MsgActions 派发的 rpg-regenerate 事件(消息气泡「重新生成」按钮)
+  useEffect(() => {
+    const handler = () => onRetry();
+    window.addEventListener('rpg-regenerate', handler);
+    return () => window.removeEventListener('rpg-regenerate', handler);
+  }, [onRetry]);
+
   /* ── rail 操作:rename / archive / delete ───────────────────────── */
   const doRename = useCallback(async (chat, title) => {
     try {

--- a/frontend/src/tavern.css
+++ b/frontend/src/tavern.css
@@ -248,7 +248,7 @@
   border-radius: 22px;
   box-shadow: 0 2px 18px -4px rgba(0, 0, 0, 0.28);
 }
-.tavern-chat .gc-composer .gc-textarea { padding: 14px 16px 4px; }
+.tavern-chat .gc-composer .gc-textarea { padding: 10px 16}
 
 /* ── 两张卡抽屉 ──────────────────────────────────────────────────── */
 .tv-drawer-backdrop {

--- a/rpg/platform_app/frontend_routes.py
+++ b/rpg/platform_app/frontend_routes.py
@@ -736,10 +736,19 @@ async def api_card_import_json(request: Request):
     raw = body.get("json") or ""
     try:
         data = json.loads(raw) if isinstance(raw, str) else raw
-    except Exception:
-        return _bad("JSON 解析失败")
+    except Exception as e:
+        return _bad(f"JSON 解析失败：{e}")
     # Accept a variety of shapes (SillyTavern v1/v2 etc.)
+    # 解包常见的外层包装（如 {"ok":true,"card":{...}}）
+    if isinstance(data, dict) and not data.get("name") and not data.get("char_name"):
+        for key in ("card", "character", "chara_card"):
+            inner = data.get(key)
+            if isinstance(inner, dict) and (inner.get("name") or inner.get("data", {}).get("name")):
+                data = inner
+                break
     name = data.get("name") or data.get("char_name") or ""
+    if not name and isinstance(data.get("data"), dict):
+        name = data["data"].get("name") or ""
     if not name:
         return _bad("缺少 name 字段")
     from . import user_cards as _uc

--- a/rpg/platform_app/tavern_cards.py
+++ b/rpg/platform_app/tavern_cards.py
@@ -283,6 +283,15 @@ def parse_card(data: dict[str, Any] | str | bytes) -> dict[str, Any]:
             raise ValueError(f"无法解析角色卡：既不是 JSON 也不是 base64({exc})") from exc
     if not isinstance(data, dict):
         raise ValueError(f"不支持的角色卡类型：{type(data)}")
+    # 解包常见的外层包装（如 {"ok":true,"card":{...}}、{"data":{...}}、{"character":{...}}）。
+    # 仅当根级缺少有效 data 时才尝试解包，避免误拆合法 V2 卡。
+    root_has_valid_data = isinstance(data.get("data"), dict) and data["data"].get("name")
+    if not root_has_valid_data:
+        for key in ("card", "character", "chara_card"):
+            inner = data.get(key)
+            if isinstance(inner, dict) and inner.get("data"):
+                data = inner
+                break
     # 是 V2 还是 V1？
     if data.get("spec") == "chara_card_v2" or data.get("spec") == "chara_card_v3":
         return _normalize_v2(data)

--- a/rpg/tools_dsl/command_dispatcher.py
+++ b/rpg/tools_dsl/command_dispatcher.py
@@ -352,10 +352,34 @@ class ToolDispatcher:
             if v is None:
                 missing.append(fld)
         if missing:
+            # 给出每个缺失字段的类型提示,方便模型自我纠正
+            props = (spec.input_schema or {}).get("properties") or {}
+            hints = []
+            for fld in missing:
+                p = props.get(fld) or {}
+                ftype = p.get("type") or "any"
+                fdesc = p.get("description") or ""
+                hint = f"{fld}({ftype})"
+                if fdesc:
+                    hint += f": {fdesc}"
+                hints.append(hint)
+            # 附带模型实际传入的字段名,帮助模型发现拼写/命名错误
+            actual_keys = sorted(env.args.keys()) if env.args else []
+            actual_hint = f"。你传入的字段是 {actual_keys}" if actual_keys else ""
+            # 当模型传入了与缺失字段名相似的字段时,显式提示正确字段名
+            typo_hint = ""
+            if actual_keys and missing:
+                for m in missing:
+                    # 简单相似度:首字母相同 or 编辑距离近的字段
+                    candidates = [k for k in actual_keys if k != m and (
+                        k[0] == m[0] or abs(len(k) - len(m)) <= 2
+                    )]
+                    if candidates:
+                        typo_hint = f"。注意:你可能误用了 {candidates},正确字段名是 '{m}'"
+                        break
             raise DispatchError(
                 "missing_required",
-                f"工具 {env.tool} 缺必填字段: {', '.join(missing)}. "
-                f"请用 ask_user_choice 让用户选 (给 3-4 个候选 + allow_free_text=true)。",
+                f"工具 {env.tool} 缺必填字段: {', '.join(hints)}{actual_hint}{typo_hint}",
             )
         # 9) trace 内去重 (同 trace 同 tool+args 只执行一次)
         if env.trace_id:

--- a/rpg/tools_dsl/command_tools.py
+++ b/rpg/tools_dsl/command_tools.py
@@ -193,13 +193,16 @@ COMMAND_TOOLS: list[dict[str, Any]] = [
     },
     {
         "name": "set_relationship",
-        "description": '设置玩家与某 NPC 的关系状态。用户写"NPC关系=信任"/"X对我警惕"等用这个工具。',
+        "description": (
+            '设置玩家与某 NPC 的关系状态。用户写"NPC关系=信任"/"X对我警惕"等用这个工具。\n'
+            "示例: set_relationship(character=\"迷迭香\", status=\"亲近\")"
+        ),
         "input_schema": {
             "type": "object",
             "properties": {
-                "character": {"type": "string", "description": "NPC 名字"},
+                "character": {"type": "string", "description": "NPC 名字(字段名是 character,不是 npc_name)"},
                 "status": {"type": "string",
-                           "description": "关系状态描述,如 '信任/警惕/敌意/亲近/紧张/疏离'"},
+                           "description": "关系状态描述(字段名是 status,不是 status_label),如 '信任/警惕/敌意/亲近/紧张/疏离'"},
             },
             "required": ["character", "status"],
         },

--- a/rpg/tools_dsl/command_tools_tavern.py
+++ b/rpg/tools_dsl/command_tools_tavern.py
@@ -560,7 +560,8 @@ def register_tavern_tools() -> None:
             description=(
                 "向玩家弹出一道有限选项的选择题(网页里以可点按钮呈现),把决定权交回玩家。\n"
                 "当剧情走到需要玩家在 2-6 个分支/偏好里抉择时调它,玩家点选后其选择会作为下一条消息发回;\n"
-                "不要替玩家做选择,也不要在正文里裸列 1/2/3。allow_free_text=true 时额外给一个自由输入入口。"
+                "不要替玩家做选择,也不要在正文里裸列 1/2/3。allow_free_text=true 时额外给一个自由输入入口。\n"
+                "注意:options 是纯字符串数组,不是对象数组! 不要用 choices/id/label,直接用 options 传字符串列表。"
             ),
             input_schema={
                 "type": "object",
@@ -568,7 +569,7 @@ def register_tavern_tools() -> None:
                     "question": {"type": "string", "description": "问题文本"},
                     "options": {
                         "type": "array", "items": {"type": "string"},
-                        "description": "2-6 个候选答案(纯字符串)",
+                        "description": "2-6 个候选答案,必须是纯字符串数组,例如 [\"选项A\", \"选项B\"]",
                         "minItems": 2, "maxItems": 6,
                     },
                     "allow_free_text": {"type": "boolean", "default": True,
@@ -582,6 +583,7 @@ def register_tavern_tools() -> None:
             destructive=False,
             input_examples=(
                 {"question": "今晚先去哪?", "options": ["天台", "图书馆", "回家"]},
+                {"question": "你要带迷迭香去哪里?", "options": ["办公室处理文件", "食堂吃早餐", "医疗部找凯尔希复查", "训练室测试源石技艺"]},
             ),
         ))
 


### PR DESCRIPTION
## 改动内容

### 角色卡导入优化
- 支持嵌套 JSON 格式（自动 unwrap `card`/`character`/`chara_card` 包装）
- 兼容 V2 角色卡（`data.name` 字段）
- 前端 `tryParseJson()` 统一处理嵌套格式
- 导入失败时显示具体解析错误信息（如缺少逗号、位置等）

### 工具调用错误提示改进
- 必填字段缺失时显示字段类型、描述和实际传入的参数名
- 新增拼写错误检测：当模型传入相似字段名时自动提示正确名称（如 `choices` → `options`）
- `ask_player_choice` 和 `set_relationship` 工具描述增强，含显式示例

### 酒馆 UI 修复
- **重新生成按钮**：Platform 版酒馆添加 `rpg-regenerate` 事件监听
- **横向滚动溢出**：`.gc-chat` 添加 `overflow-x: hidden` 防止消息操作按钮撑出
- **输入框垂直居中**：将非对称 padding 改为对称值

### 涉及文件（10 个）
| 文件 | 改动 |
|------|------|
| `frontend/src/pages/cards.jsx` | 嵌套 JSON unwrap |
| `frontend/src/mobile/pages/MobileCards.jsx` | 同上（移动端） |
| `frontend/src/pages/tavern.jsx` | regenerate 事件监听 |
| `frontend/src/pages/tavern-platform.css` | overflow-x + padding |
| `frontend/src/tavern.css` | textarea padding |
| `rpg/platform_app/frontend_routes.py` | JSON 错误详情 + 嵌套 unwrap |
| `rpg/platform_app/tavern_cards.py` | parse_card 嵌套支持 |
| `rpg/tools_dsl/command_dispatcher.py` | 拼写检测 + 字段提示 |
| `rpg/tools_dsl/command_tools.py` | set_relationship 描述 |
| `rpg/tools_dsl/command_tools_tavern.py` | ask_player_choice 描述 |