### PR TITLE
feat: GM消息内联编辑

### DIFF
--- a/frontend/src/api-client.js
+++ b/frontend/src/api-client.js
@@ -924,6 +924,7 @@
       opening: (body, handlers) => sseStream(`${API_PREFIX}/opening`, body || {}, _wbHook(handlers)),
       chat: (body, handlers) => sseStream(`${API_PREFIX}/chat`, body || {}, _wbHook(handlers)),
       chatEstimate: (body) => POST(`${API_PREFIX}/chat/estimate`, body),
+      editMessage: (body) => POST(`${API_PREFIX}/message/edit`, body),
       contextBreakdown: () => GET(`${API_PREFIX}/chat/context-breakdown`),
       memoryMode: (mode) => POST(`${API_PREFIX}/memory/mode`, { mode }),
       memoryAdd: (body) => POST(`${API_PREFIX}/memory/add`, body),

--- a/frontend/src/game-app.jsx
+++ b/frontend/src/game-app.jsx
@@ -380,6 +380,7 @@ function MsgActions({ text, ts, msgIndex, totalMsgs, commitId, saveId, role, met
   // task 116c: 删除消息 (软回滚) — 弹窗确认 + 进度
   const [delOpen, setDelOpen] = useStateA(false);
   const [delBusy, setDelBusy] = useStateA(false);
+
   const onCopy = async () => {
     const txt = text || "";
     let ok = false;
@@ -512,6 +513,12 @@ function MsgActions({ text, ts, msgIndex, totalMsgs, commitId, saveId, role, met
       setDelBusy(false);
     }
   };
+  // 编辑消息:仅 assistant(GM) 消息可编辑 → 派发事件让 NarrativeBlock 进入内联编辑
+  const canEdit = role === "assistant" && saveId != null && msgIndex != null && msgIndex >= 0;
+  const onEdit = () => {
+    if (!canEdit) return;
+    window.dispatchEvent(new CustomEvent("rpg-edit-message", { detail: { saveId, msgIndex } }));
+  };
   return (
     <>
       <div className="gc-msg-actions">
@@ -534,6 +541,15 @@ function MsgActions({ text, ts, msgIndex, totalMsgs, commitId, saveId, role, met
           onClick={onRegenerate}>
           <Icon name="refresh" size={12} />
         </button>
+        {canEdit && (
+          <button
+            className="iconbtn gc-msg-act"
+            data-tip={t('game.app.msg.edit_tip')}
+            data-tip-pos="below"
+            onClick={onEdit}>
+            <Icon name="edit" size={12} />
+          </button>
+        )}
         <button
           className="iconbtn gc-msg-act gc-msg-act-danger"
           data-tip={canDelete ? t('game.app.msg.delete_tip') : t('game.app.msg.delete_no_ctx_tip')}
@@ -555,6 +571,7 @@ function MsgActions({ text, ts, msgIndex, totalMsgs, commitId, saveId, role, met
         onClose={() => !delBusy && setDelOpen(false)}
         onConfirm={doDelete}
       />
+
     </>
   );
 }
@@ -707,6 +724,47 @@ function renderNarrativeWithInlineTools(rawText, toolOps, renderTool, streaming,
 function NarrativeBlock({ text, streaming, ts, msgIndex, saveId, commitId, thinking, speakerName, speakerAvatar, tag, hideMeta, meta, images, toolOps, renderTool }) {
   const { t } = useTranslation();
   const displayText = stripStateOpsForDisplay(text);
+  // 内联编辑状态:点击 MsgActions 的编辑按钮时通过事件激活
+  const [editing, setEditing] = useStateA(false);
+  const [editDraft, setEditDraft] = useStateA("");
+  const [editSaving, setEditSaving] = useStateA(false);
+  const editRef = useRefA(null);
+  useEffectA(() => {
+    const handler = (e) => {
+      const d = e.detail || {};
+      if (d.saveId === saveId && d.msgIndex === msgIndex) {
+        setEditDraft(displayText || "");
+        setEditing(true);
+      }
+    };
+    window.addEventListener("rpg-edit-message", handler);
+    return () => window.removeEventListener("rpg-edit-message", handler);
+  }, [saveId, msgIndex, displayText]);
+  // 进入编辑模式后自动 focus textarea 并定位到末尾
+  useEffectA(() => {
+    if (editing && editRef.current) {
+      const el = editRef.current;
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    }
+  }, [editing]);
+  const doEditSave = async () => {
+    if (editSaving) return;
+    setEditSaving(true);
+    try {
+      const r = await window.api.game.editMessage({ save_id: saveId, message_index: msgIndex, content: editDraft });
+      if (r && r.ok === false) throw new Error(r.error || "edit failed");
+      setEditing(false);
+      try {
+        window.dispatchEvent(new CustomEvent("rpg-state-reload", { detail: { reason: "message_edit" } }));
+      } catch (_) {}
+      window.toast?.(t('game.app.msg.edit_saved'), { kind: "ok", duration: 1800 });
+    } catch (e) {
+      window.toast?.(t('game.app.msg.edit_failed'), { kind: "danger", detail: e?.message, duration: 3000 });
+    } finally {
+      setEditSaving(false);
+    }
+  };
   // task 90: 用 RpgMarkdown.Block 渲染 markdown (** / # / list / code / link...)
   // window.RpgMarkdown 由 markdown-render.jsx 提供,加载顺序在 game-app.jsx 之前。
   const MdBlock = RpgMarkdown.Block;
@@ -749,16 +807,51 @@ function NarrativeBlock({ text, streaming, ts, msgIndex, saveId, commitId, think
         </div>
       )}
       <div className="gc-msg-body serif">
-        {(Array.isArray(toolOps) && toolOps.length > 0 && typeof renderTool === 'function')
-          ? renderNarrativeWithInlineTools(text, toolOps, renderTool, streaming, MdBlock)
-          : (MdBlock
-              ? <MdBlock text={displayText || ""} streaming={!!streaming} className="rpg-md" />
-              : (displayText || "").split(/\n\n+/).map((p, i) =>
-                  <p key={i}>{p}{streaming && i === (displayText || "").split(/\n\n+/).length - 1 && <span className="gc-cursor" />}</p>
+        {editing ? (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <textarea
+              ref={editRef}
+              value={editDraft}
+              onChange={e => setEditDraft(e.target.value)}
+              disabled={editSaving}
+              onKeyDown={e => {
+                if (e.key === "s" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); doEditSave(); }
+                if (e.key === "Escape") { setEditing(false); }
+              }}
+              style={{
+                width: "100%", minHeight: 180, maxHeight: "60vh", resize: "vertical",
+                fontFamily: "var(--font-serif, inherit)", fontSize: "var(--d-narrative, 16.5px)",
+                lineHeight: "var(--d-line, 1.78)", padding: "10px 12px", borderRadius: 8,
+                border: "1px solid var(--accent-edge, var(--line))",
+                background: "var(--bg-deep, #1a1816)", color: "var(--text)", outline: "none",
+                letterSpacing: "0.02em",
+              }}
+            />
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+              <button className="btn ghost" disabled={editSaving} onClick={() => setEditing(false)}>
+                {t('common.cancel')}
+              </button>
+              <button className="btn primary" disabled={editSaving || !editDraft.trim()} onClick={doEditSave}>
+                {editSaving
+                  ? <><span className="gc-spinner spin" /> {t('game.app.edit_modal.saving')}</>
+                  : <><Icon name="check" size={12} /> {t('game.app.edit_modal.confirm')}</>}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            {(Array.isArray(toolOps) && toolOps.length > 0 && typeof renderTool === 'function')
+              ? renderNarrativeWithInlineTools(text, toolOps, renderTool, streaming, MdBlock)
+              : (MdBlock
+                  ? <MdBlock text={displayText || ""} streaming={!!streaming} className="rpg-md" />
+                  : (displayText || "").split(/\n\n+/).map((p, i) =>
+                      <p key={i}>{p}{streaming && i === (displayText || "").split(/\n\n+/).length - 1 && <span className="gc-cursor" />}</p>
+                    )
                 )
-            )
-        }
-        <ChatImageGroup images={images} />
+            }
+            <ChatImageGroup images={images} />
+          </>
+        )}
       </div>
       {!streaming && <MsgActions text={displayText} ts={ts || "—"} msgIndex={msgIndex} saveId={saveId} commitId={commitId} role="assistant" meta={meta} />}
     </div>);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2880,7 +2880,10 @@
         "delete_detail": "Deleted {{count}} message(s) · restored to turn {{turn}}",
         "delete_trash": "old branch saved as {{name}}",
         "deleted": "Messages deleted",
-        "delete_failed": "Delete failed"
+        "delete_failed": "Delete failed",
+        "edit_tip": "Edit this message",
+        "edit_saved": "Message updated",
+        "edit_failed": "Edit failed"
       },
       "delete_modal": {
         "eyebrow": "Danger",
@@ -2905,6 +2908,12 @@
         "title": "Fork at this node",
         "new_branch": "New Branch",
         "body": "Later messages will be kept on the original branch; the new branch continues from here."
+      },
+      "edit_modal": {
+        "eyebrow": "Edit GM Output",
+        "title": "Modify This Turn",
+        "saving": "Saving…",
+        "confirm": "Save"
       },
       "narrative": {
         "main_agent": "Main Agent",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -2971,7 +2971,10 @@
         "delete_detail": "已删 {{count}} 条消息 · 回到第 {{turn}} 回合",
         "delete_trash": "旧分支已存为 {{name}}",
         "deleted": "消息已删除",
-        "delete_failed": "删除失败"
+        "delete_failed": "删除失败",
+        "edit_tip": "编辑此消息",
+        "edit_saved": "消息已更新",
+        "edit_failed": "编辑失败"
       },
       "delete_modal": {
         "eyebrow": "危险操作",
@@ -2996,6 +2999,12 @@
         "title": "在此节点开新分支",
         "new_branch": "新建分支",
         "body": "当前节点之后的消息会保留在原分支，新分支从这里继续。"
+      },
+      "edit_modal": {
+        "eyebrow": "编辑 GM 输出",
+        "title": "修改本轮回复",
+        "saving": "保存中…",
+        "confirm": "保存修改"
       },
       "narrative": {
         "main_agent": "主代理",

--- a/rpg/routes/game.py
+++ b/rpg/routes/game.py
@@ -295,6 +295,18 @@ async def api_opening(
                         state_data=state.data,
                     )
                     platform_knowledge.ensure_game_session(persist_user_id, active_save_id, state.data)
+                    # 写入 messages 表:kb_native 存档 materialize() 从 messages 重建 history,
+                    # 若不写,开场白在 messages 表缺失 → materialize 丢开场 → 前端只显示后续对话。
+                    try:
+                        platform_knowledge.record_turn_messages(
+                            persist_user_id,
+                            active_save_id,
+                            state.data,
+                            "",
+                            opening_for_history,
+                        )
+                    except Exception:
+                        pass
                 else:
                     _persist_runtime_checkpoint(state, api_user)
             except Exception:
@@ -855,3 +867,59 @@ async def api_save(
         return JSONResponse({"ok": False, "error": result.error}, status_code=400)
     _persist_runtime_checkpoint(state, api_user)
     return JSONResponse({"ok": True, "state": _payload(api_user)})
+
+
+@router.post("/api/message/edit", response_model=GenericOkResponse, responses=COMMON_ERROR_RESPONSES)
+async def api_message_edit(
+    body: dict[str, Any],
+    api_user: dict[str, Any] | None = Depends(get_current_user),
+) -> JSONResponse:
+    """编辑一条历史消息的内容(messages 表 + state blob history 同步更新)。
+
+    body: {save_id: int, message_index: int, content: str}
+    message_index: history 数组索引(0-based),与 /api/state 返回的 history 顺序一致。
+    """
+    if not api_user:
+        return JSONResponse({"ok": False, "error": "auth required"}, status_code=401)
+    save_id = body.get("save_id")
+    msg_index = body.get("message_index")
+    new_content = body.get("content")
+    if save_id is None or msg_index is None or new_content is None:
+        return JSONResponse({"ok": False, "error": "save_id, message_index, content required"}, status_code=400)
+    try:
+        msg_index = int(msg_index)
+        save_id = int(save_id)
+    except (TypeError, ValueError):
+        return JSONResponse({"ok": False, "error": "invalid save_id or message_index"}, status_code=400)
+
+    from platform_app.db import connect
+    try:
+        with connect() as db:
+            # 按 turn, id 排序拿到有序消息列表,定位到目标行
+            rows = db.execute(
+                "select id from messages where save_id = %s order by turn, id",
+                (save_id,),
+            ).fetchall()
+            if msg_index < 0 or msg_index >= len(rows):
+                return JSONResponse({"ok": False, "error": f"message_index {msg_index} out of range (0-{len(rows)-1})"}, status_code=400)
+            target_id = rows[msg_index]["id"]
+            db.execute(
+                "update messages set content = %s where id = %s",
+                (str(new_content), target_id),
+            )
+            db.commit()
+        # 同步更新 state blob history(非 kb_native 存档直接读 blob;
+        # kb_native 存档 materialize 从 messages 读,上面已更新)
+        try:
+            from app import _ensure_loaded, _resolve_persist_target
+            state = _ensure_loaded(api_user)
+            hist = state.data.get("history") or []
+            if 0 <= msg_index < len(hist):
+                hist[msg_index]["content"] = str(new_content)
+                state.save()
+        except Exception:
+            pass  # blob 同步失败不影响 messages 表已更新的事实
+    except Exception as e:
+        _log.exception("[message/edit] failed")
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+    return JSONResponse({"ok": True})


### PR DESCRIPTION
## 改动内容

- **MsgActions** 添加编辑按钮(✏️)，仅 assistant(GM) 消息可编辑
- **NarrativeBlock** 支持内联 textarea 编辑，Cmd+S 保存 / Esc 取消
- 后端 `POST /api/message/edit` 端点，同步更新 messages 表 + state blob
- opening message 写入 messages 表，修复 kb_native 存档 materialize 丢开场白
- i18n: zh-CN / en 编辑相关文案