### PR TITLE
fix: 手机端GM输出泄露JSON state ops

### DIFF
--- a/frontend/src/mobile/game/MobileGame.jsx
+++ b/frontend/src/mobile/game/MobileGame.jsx
@@ -16,6 +16,7 @@ import { MobileComposer } from '../Composer.jsx';
 import { MobilePanel, MOBILE_PANEL_TABS } from './panels.jsx';
 import AgentModelPicker from '../../components/AgentModelPicker.jsx';
 import { useStickToBottom } from '../../hooks/useStickToBottom.js';
+import { stripNarrativeOps } from '../../narrative-strip.js';
 
 const SLASH_GROUPS = () => [
   { title: i18n.t('mobile.game.slash.group_query'), items: [
@@ -481,7 +482,7 @@ export function MobileGame(gc) {
                 onTouchStart={() => startPress(i)} onTouchEnd={cancelPress} onTouchMove={cancelPress}
                 onContextMenu={(e) => { e.preventDefault(); setPressed(i); setSheet({ type: 'msg', data: i }); }}>
                 <div className="msg-meta"><span className="msg-tag">GM</span>{m._thinking ? <span className="msg-gts mono">{t('mobile.game.chat.thinking')}</span> : null}</div>
-                <div className="msg-body serif">{paras(m.content)}</div>
+                <div className="msg-body serif">{paras(stripNarrativeOps(m.content))}</div>
               </div>
             ) : (
               <div key={i} className={`msg msg-player ${pressed === i ? 'pressed' : ''}`}

--- a/frontend/src/mobile/pages/MobileTavern.jsx
+++ b/frontend/src/mobile/pages/MobileTavern.jsx
@@ -15,6 +15,7 @@ import i18n from '../../i18n';
 import { Icon } from '../icons.jsx';
 import { MobileComposer } from '../Composer.jsx';
 import { useStickToBottom } from '../../hooks/useStickToBottom.js';
+import { stripNarrativeOps } from '../../narrative-strip.js';
 import {
   useTavernChatRun, applyTavernState, abortRun,
   toolCallInline, toolResultInline,
@@ -809,7 +810,7 @@ function ChatView({
                   </div>
                   {m._thinking && <ThinkingBlock text={m._thinking} />}
                   <div className="msg-body">
-                    <Paras text={m.content} />
+                    <Paras text={stripNarrativeOps(m.content)} />
                     {isStreaming && (
                       <span className="tv-m-cursor" aria-hidden="true" />
                     )}


### PR DESCRIPTION
## 问题

手机模式下 GM 输出直接显示 `[{"op":"set","path":"world.time","value":"序章·开端"}]` JSON 结构，未被过滤。

## 修复

- `MobileGame.jsx`: 导入 `stripNarrativeOps`，GM 消息渲染前过滤 JSON ops
- `MobileTavern.jsx`: 同上