### PR TITLE
fix(a11y): 30+ 处图标按钮 aria-label + 伪按钮替换 + 键盘支持

### DIFF
--- a/frontend/src/branch-graph.jsx
+++ b/frontend/src/branch-graph.jsx
@@ -366,17 +366,17 @@ function BranchGraph({ data, variant = "full", headOnly, selectedId, onActivate,
                 {conf.showActions && (
                   <span className="bg-actions">
                     {onContinue && (
-                      <button className="iconbtn" data-tip={t('branch_graph.action.continue')} onClick={(e) => { e.stopPropagation(); onContinue(cid); }}>
+                      <button className="iconbtn" data-tip={t('branch_graph.action.continue')} aria-label={t('branch_graph.action.continue')} onClick={(e) => { e.stopPropagation(); onContinue(cid); }}>
                         <Icon name="play" size={11} />
                       </button>
                     )}
                     {onActivate && !isActive && (
-                      <button className="iconbtn" data-tip={t('branch_graph.action.activate')} onClick={(e) => { e.stopPropagation(); onActivate(cid); }}>
+                      <button className="iconbtn" data-tip={t('branch_graph.action.activate')} aria-label={t('branch_graph.action.activate')} onClick={(e) => { e.stopPropagation(); onActivate(cid); }}>
                         <Icon name="check" size={11} />
                       </button>
                     )}
                     {onDelete && (
-                      <button className="iconbtn" data-tip={t('branch_graph.action.delete_subtree')} onClick={(e) => { e.stopPropagation(); onDelete(cid); }}>
+                      <button className="iconbtn" data-tip={t('branch_graph.action.delete_subtree')} aria-label={t('branch_graph.action.delete_subtree')} onClick={(e) => { e.stopPropagation(); onDelete(cid); }}>
                         <Icon name="trash" size={11} />
                       </button>
                     )}

--- a/frontend/src/game-app.jsx
+++ b/frontend/src/game-app.jsx
@@ -40,7 +40,7 @@ function LeftRail({ collapsed, onToggle, state, runState, onNew, onSave, onSwitc
             <span className="muted-2" style={{ fontSize: 11 }}>RPG Roleplay · {(state && state.world && state.world.timeline && state.world.timeline.current_phase) || "—"}</span>
           </div>
         </div>
-        <button className="iconbtn" onClick={onToggle} data-tip={t('game.app.rail.collapse_tip')} data-tip-pos="below">
+        <button className="iconbtn" onClick={onToggle} data-tip={t('game.app.rail.collapse_tip')} data-tip-pos="below" aria-label={t('game.app.rail.collapse_tip')}>
           <Icon name="chevron_left" size={14} />
         </button>
       </div>
@@ -48,7 +48,7 @@ function LeftRail({ collapsed, onToggle, state, runState, onNew, onSave, onSwitc
       <div className="gc-rail-section">
         <div className="gc-rail-section-head">
           <span>{t('game.app.rail.current_save')}</span>
-          <button className="iconbtn" data-tip={t('game.app.rail.new_game_tip')} onClick={onNew}><Icon name="plus" size={12} /></button>
+          <button className="iconbtn" data-tip={t('game.app.rail.new_game_tip')} onClick={onNew} aria-label={t('game.app.rail.new_game_tip')}><Icon name="plus" size={12} /></button>
         </div>
         <div className="gc-rail-save-display">
           {(() => {
@@ -74,7 +74,7 @@ function LeftRail({ collapsed, onToggle, state, runState, onNew, onSave, onSwitc
         </div>
         <div className="gc-rail-quick">
           <button className="btn ghost" onClick={onSave} data-tip={t('game.app.rail.manual_save_tip')}><Icon name="save" size={12} /> {t('common.save')}</button>
-          <button className="btn ghost" onClick={() => setBranchOpen(o => !o)} data-tip={t('game.app.rail.branch_tip')}><Icon name="branch" size={12} /> {t('game.app.rail.branch_btn')}</button>
+          <button className="btn ghost" onClick={() => setBranchOpen(o => !o)} data-tip={t('game.app.rail.branch_tip')} aria-label={t('game.app.rail.branch_tip')}><Icon name="branch" size={12} /> {t('game.app.rail.branch_btn')}</button>
         </div>
         {/* task 48：传 currentSaveId / state._raw.save_id，BranchTreeRail 走真 /api/branches */}
         {branchOpen && <BranchTreeRail saveId={currentSaveId || state?._raw?.save_id || null} />}
@@ -83,13 +83,13 @@ function LeftRail({ collapsed, onToggle, state, runState, onNew, onSave, onSwitc
       <div className="gc-rail-section">
         <div className="gc-rail-section-head"><span>{t('game.app.rail.memory_mode')}</span></div>
         <div className="seg gc-mem-seg">
-          <button className={m.mode === "normal" ? "active" : ""} data-tip={t('game.app.rail.memory_normal_tip')} onClick={() => onMemoryMode?.("normal")}>
+          <button className={m.mode === "normal" ? "active" : ""} data-tip={t('game.app.rail.memory_normal_tip')} onClick={() => onMemoryMode?.("normal")} aria-label={t('game.app.rail.memory_normal_tip')}>
             <Icon name="memory" /> {t('game.app.rail.memory_normal')}
           </button>
-          <button className={m.mode === "deep" ? "active" : ""} data-tip={t('game.app.rail.memory_deep_tip')} onClick={() => onMemoryMode?.("deep")}>
+          <button className={m.mode === "deep" ? "active" : ""} data-tip={t('game.app.rail.memory_deep_tip')} onClick={() => onMemoryMode?.("deep")} aria-label={t('game.app.rail.memory_deep_tip')}>
             <Icon name="sparkle" /> {t('game.app.rail.memory_deep')}
           </button>
-          <button className={m.mode === "off" ? "active" : ""} data-tip={t('game.app.rail.memory_off_tip')} onClick={() => onMemoryMode?.("off")}>
+          <button className={m.mode === "off" ? "active" : ""} data-tip={t('game.app.rail.memory_off_tip')} onClick={() => onMemoryMode?.("off")} aria-label={t('game.app.rail.memory_off_tip')}>
             <Icon name="eye_off" /> {t('common.close')}
           </button>
         </div>
@@ -344,7 +344,8 @@ function RunDetailRail({ runState }) {
         </span>
         {rawSteps.length > 6 && (
           <button className="iconbtn" style={{ padding: "2px 8px", fontSize: 10.5, whiteSpace: "nowrap", width: "auto", height: "auto" }}
-            onClick={(e) => { e.stopPropagation(); setExpanded(v => !v); }}>
+            onClick={(e) => { e.stopPropagation(); setExpanded(v => !v); }}
+            aria-label={expanded ? t('game.app.run.collapse') : t('game.app.run.show_all', { count: rawSteps.length })}>
             {expanded ? t('game.app.run.collapse') : t('game.app.run.show_all', { count: rawSteps.length })}
           </button>
         )}
@@ -515,7 +516,7 @@ function MsgActions({ text, ts, msgIndex, totalMsgs, commitId, saveId, role, met
   return (
     <>
       <div className="gc-msg-actions">
-        <button className="iconbtn gc-msg-act" data-tip={copied ? t('game.app.msg.copied') : t('game.app.msg.copy')} data-tip-pos="below" onClick={onCopy}>
+        <button className="iconbtn gc-msg-act" data-tip={copied ? t('game.app.msg.copied') : t('game.app.msg.copy')} data-tip-pos="below" onClick={onCopy} aria-label={copied ? t('game.app.msg.copied') : t('game.app.msg.copy')}>
           <Icon name={copied ? "check" : "file"} size={12} />
         </button>
         <button
@@ -523,7 +524,7 @@ function MsgActions({ text, ts, msgIndex, totalMsgs, commitId, saveId, role, met
           data-tip={canFork ? t('game.app.msg.fork_tip') : t('game.app.msg.fork_no_ctx_tip')}
           data-tip-pos="below"
           disabled={!canFork}
-          onClick={onFork}>
+          aria-label={canFork ? t('game.app.msg.fork_tip') : t('game.app.msg.fork_no_ctx_tip')} onClick={onFork}>
           <Icon name="fork" size={12} />
         </button>
         <button
@@ -531,7 +532,7 @@ function MsgActions({ text, ts, msgIndex, totalMsgs, commitId, saveId, role, met
           data-tip={canRegen ? t('game.app.msg.regen_tip') : t('game.app.msg.regen_no_ctx_tip')}
           data-tip-pos="below"
           disabled={!canRegen}
-          onClick={onRegenerate}>
+          aria-label={canRegen ? t('game.app.msg.regen_tip') : t('game.app.msg.regen_no_ctx_tip')} onClick={onRegenerate}>
           <Icon name="refresh" size={12} />
         </button>
         <button
@@ -539,7 +540,7 @@ function MsgActions({ text, ts, msgIndex, totalMsgs, commitId, saveId, role, met
           data-tip={canDelete ? t('game.app.msg.delete_tip') : t('game.app.msg.delete_no_ctx_tip')}
           data-tip-pos="below"
           disabled={!canDelete}
-          onClick={() => setDelOpen(true)}>
+          aria-label={canDelete ? t('game.app.msg.delete_tip') : t('game.app.msg.delete_no_ctx_tip')} onClick={() => setDelOpen(true)}>
           <Icon name="trash" size={12} />
         </button>
         <span className="gc-msg-ts mono">{ts}</span>
@@ -1050,9 +1051,9 @@ function ChatArea({ history, runState, runStyle, narrativeFont, narrativeSize, h
         {hiddenCount > 0 && (
           <div className="muted-2" style={{textAlign: "center", padding: "8px 0", fontSize: 12}}>
             {t('game.app.chat.hidden_count', { count: hiddenCount })} ·{" "}
-            <a href="#" onClick={(e) => { e.preventDefault(); setExtra(x => x + HISTORY_WINDOW); }}>
+            <button className="link" onClick={() => setExtra(x => x + HISTORY_WINDOW)}>
               {t('game.app.chat.load_more', { count: Math.min(HISTORY_WINDOW, hiddenCount) })}
-            </a>
+            </button>
             {" · "}
             <span className="muted">{t('game.app.chat.full_history_hint')}</span>
           </div>
@@ -1190,6 +1191,7 @@ function BranchTreeRail({ saveId }) {
         <a className="iconbtn" href="/saves-branches"
            target="_blank" rel="noopener noreferrer"
            data-tip={t('game.app.branch.open_full_tip')} data-tip-pos="below"
+           aria-label={t('game.app.branch.open_full_tip')}
            style={{width: 18, height: 18}}>
           <Icon name="arrow_right" size={10} />
         </a>

--- a/frontend/src/game-composer.jsx
+++ b/frontend/src/game-composer.jsx
@@ -866,7 +866,7 @@ function Composer({
             <span key={i} className="gc-attachment">
               <Icon name={a.kind === "image" ? "image" : a.kind === "skill" ? "spark" : a.kind === "mcp" ? "diamond" : "file"} size={12} />
               <span className="truncate">{a.name}</span>
-              <button onClick={() => removeAttachment(i)} className="iconbtn" style={{width: 18, height: 18}}><Icon name="close" size={10} /></button>
+              <button onClick={() => removeAttachment(i)} className="iconbtn" style={{width: 18, height: 18}} aria-label={t('game.composer.remove_attachment')}><Icon name="close" size={10} /></button>
             </span>
           ))}
         </div>
@@ -877,7 +877,7 @@ function Composer({
             <div className="gc-cmd-chip">
               <span className="mono">{pickedCommand.trigger.trim()}</span>
               <span className="gc-cmd-chip-label">{pickedCommand.label}</span>
-              <button className="iconbtn" data-tip={t('game.composer.remove_command_tip')} onClick={onClearCommand} style={{width: 18, height: 18}}>
+              <button className="iconbtn" data-tip={t('game.composer.remove_command_tip')} onClick={onClearCommand} style={{width: 18, height: 18}} aria-label={t('game.composer.remove_command_tip')}>
                 <Icon name="close" size={10} />
               </button>
             </div>
@@ -1181,6 +1181,8 @@ function ContextUsage({ gameState, used: usedProp, cap: capProp }) {
   return (
     <span className={`gc-context-usage gc-context-usage-ring${open ? " active" : ""}`}
       ref={wrapRef}
+      role="button" tabIndex={0}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setOpen(o => !o); } }}
       onClick={() => setOpen(o => !o)}
       title={t('game.composer.context_usage_tip')}>
       <svg width="20" height="20" viewBox="0 0 20 20" style={{display: "block"}}>

--- a/frontend/src/game-panels.jsx
+++ b/frontend/src/game-panels.jsx
@@ -430,7 +430,7 @@ function PanelMemory({ state, density }) {
       <div className="gp-section">
         <div className="section-head">
           <h3>{t('game.memory.pinned')}<span className="muted-2" style={{marginLeft: 8, fontSize: 11, textTransform: "none"}}>{t('game.memory.pinned_subtitle')}</span></h3>
-          <button className="iconbtn" data-tip={t('game.memory.add_pinned_tip')} data-tip-pos="below"
+          <button className="iconbtn" data-tip={t('game.memory.add_pinned_tip')} data-tip-pos="below" aria-label={t('game.memory.add_pinned_tip')}
             onClick={async () => {
               const txt = prompt(t('game.memory.add_pinned_prompt'), "");
               if (!txt) return;
@@ -447,7 +447,7 @@ function PanelMemory({ state, density }) {
             <li key={i}>
               <span className="gp-pin-mark"><Icon name="pin" size={12} /></span>
               <span className="serif">{item}</span>
-              <button className="iconbtn" data-tip={t('game.memory.unpin_tip')}
+              <button className="iconbtn" data-tip={t('game.memory.unpin_tip')} aria-label={t('game.memory.unpin_tip')}
                 onClick={async () => {
                   if (!confirm(t('game.memory.unpin_confirm'))) return;
                   try { await window.api.game.memoryRemove({ bucket: "pinned", index: i }); try { window.dispatchEvent(new CustomEvent('game-state-refresh')); } catch (_) {} window.__apiToast?.(t('game.memory.unpinned_ok'), { kind: "ok" }); }
@@ -829,7 +829,7 @@ function PanelCharacters({ state }) {
           </div>
         )}
         {/* 手动添加关系入口 */}
-        <button className="iconbtn" style={{marginTop: 8, fontSize: 12, padding: "4px 10px", width: "auto"}}
+        <button className="iconbtn" style={{marginTop: 8, fontSize: 12, padding: "4px 10px", width: "auto"}} aria-label={t('game.characters.add_relationship')}
           onClick={async () => {
             const ch = prompt(t('game.characters.npc_name_prompt'), "");
             if (!ch) return;

--- a/frontend/src/login-app.jsx
+++ b/frontend/src/login-app.jsx
@@ -1049,14 +1049,13 @@ function LoginApp() {
                 ? t('auth.min_password', { min: minPw })
                 : ''}
             </span>
-            <a href="#"
-               onClick={(e) => {
-                 e.preventDefault();
+            <button
+               onClick={() => {
                  setForgotEmail('');
                  setErr(''); setNotice('');
                  setMode('forgot');
                }}
-               style={{borderBottom: 0, color: 'var(--muted)', cursor: 'pointer'}}>{t('auth.forget_password')}</a>
+               style={{background: 'none', border: 'none', color: 'var(--muted)', cursor: 'pointer', fontSize: 'inherit', padding: 0}}>{t('auth.forget_password')}</button>
           </div>
         </form>}
       </div>

--- a/frontend/src/platform-app.jsx
+++ b/frontend/src/platform-app.jsx
@@ -256,22 +256,22 @@ function PromptModal({ open, eyebrow, title, fields = [], submitLabel = "", dang
         <div className="pl-modal-form">
           {fields.map(f => (
             <div key={f.key} className="pl-field">
-              <label>{f.label} {f.hint && <span className="muted-2" style={{textTransform: "none", letterSpacing: 0, marginLeft: 6}}>{f.hint}</span>}</label>
+              <label htmlFor={f.key}>{f.label} {f.hint && <span className="muted-2" style={{textTransform: "none", letterSpacing: 0, marginLeft: 6}}>{f.hint}</span>}</label>
               {f.type === "textarea" ? (
-                <textarea value={values[f.key] || ""} onChange={(e) => update(f.key, e.target.value)} placeholder={f.placeholder} rows={f.rows || 3} />
+                <textarea id={f.key} value={values[f.key] || ""} onChange={(e) => update(f.key, e.target.value)} placeholder={f.placeholder} rows={f.rows || 3} />
               ) : f.type === "select" ? (
-                <select value={values[f.key] || ""} onChange={(e) => update(f.key, e.target.value)}>
+                <select id={f.key} value={values[f.key] || ""} onChange={(e) => update(f.key, e.target.value)}>
                   {f.options.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
                 </select>
               ) : f.type === "file" ? (
                 <div className="pl-drop" style={{padding: "14px 16px"}}>
                   <Icon name="upload" size={18} style={{color: "var(--muted)"}} />
                   <strong>{t('platform.shell.drop_files')}</strong>
-                  <a href="#" onClick={(e) => { e.preventDefault(); update(f.key, "example.png"); }}>{t('platform.shell.choose_file')}</a>
+                  <button className="link" onClick={() => update(f.key, "example.png")}>{t('platform.shell.choose_file')}</button>
                   {values[f.key] && <span className="mono muted" style={{fontSize: 11.5}}>{values[f.key]}</span>}
                 </div>
               ) : (
-                <input type={f.type || "text"} className={f.mono ? "mono" : ""}
+                <input id={f.key} type={f.type || "text"} className={f.mono ? "mono" : ""}
                   value={values[f.key] || ""} onChange={(e) => update(f.key, e.target.value)}
                   placeholder={f.placeholder} autoFocus={f === fields[0]} />
               )}
@@ -891,7 +891,7 @@ function UnifiedSearch({ open, onClose, setPage }) {
             ref={inputRef}
             value={q}
             onChange={(e) => { setQ(e.target.value); setActiveIdx(0); }}
-            placeholder={tSearch('platform.search.placeholder')}
+            placeholder={tSearch('platform.search.placeholder')} aria-label={tSearch('platform.search.placeholder')}
           />
           <span className="pl-search-kbd">
             <span className="kbd">Esc</span>
@@ -3880,7 +3880,7 @@ function ApiList() {
         <div className="pl-sec-head">
           <h2>稳定接口 <span className="muted-2">v1 · {filtered.length} 条 · {Object.keys(groups).length} 组</span></h2>
           <div className="pl-sec-tools" style={{flex: 1, maxWidth: 320}}>
-            <input style={{height: 28, fontSize: 12}} placeholder="搜索路径或描述..." value={q} onChange={(e) => setQ(e.target.value)} />
+            <input style={{height: 28, fontSize: 12}} placeholder="搜索路径或描述..." aria-label="搜索路径或描述" value={q} onChange={(e) => setQ(e.target.value)} />
           </div>
         </div>
         {Object.entries(groups).map(([group, items]) => (

--- a/frontend/src/tavern-app.jsx
+++ b/frontend/src/tavern-app.jsx
@@ -93,6 +93,7 @@ export function TavernChatItem({ chat, active, onOpen, onRename, onArchive, onDe
       onClick={() => { if (!editing) onOpen(chat); }}
       role="button"
       tabIndex={0}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); if (!editing) onOpen(chat); } }}
     >
       <AvatarImg src={chat.avatar_path || null} name={chat.character_name || chat.title || '?'} size={36} shape="circle" className="tv-chat-avatar" />
       <div className="tv-chat-main">
@@ -125,7 +126,7 @@ export function TavernChatItem({ chat, active, onOpen, onRename, onArchive, onDe
           : <div className="tv-chat-snippet muted-2" style={{ fontStyle: 'italic' }}>{chat.character_name || tl('tavern_app.chat_item.fallback_char')}</div>}
       </div>
       <div className="tv-chat-menu-wrap" onClick={(e) => e.stopPropagation()}>
-        <button className="iconbtn tv-chat-menu-btn" onClick={() => setMenuOpen((v) => !v)} data-tip={tl('tavern_app.chat_item.menu_more')}>
+        <button className="iconbtn tv-chat-menu-btn" onClick={() => setMenuOpen((v) => !v)} data-tip={tl('tavern_app.chat_item.menu_more')} aria-label={tl('tavern_app.chat_item.menu_more')}>
           <Icon name="more" size={14} />
         </button>
         {menuOpen && (
@@ -230,11 +231,11 @@ function TavernHeader({ chat, character, persona, onOpenDrawer, onExport, onOpen
   const charName = (character && character.name) || (chat && chat.character_name) || '';
   return (
     <header className="tv-header">
-      <button className="iconbtn tv-mobile-nav" onClick={onOpenNav} data-tip={t('tavern_app.header.chat_list')}>
+      <button className="iconbtn tv-mobile-nav" onClick={onOpenNav} data-tip={t('tavern_app.header.chat_list')} aria-label={t('tavern_app.header.chat_list')}>
         <Icon name="menu" size={16} />
       </button>
       {railCollapsed && (
-        <button className="iconbtn" onClick={onExpandRail} data-tip={t('tavern_app.header.expand_rail')}>
+        <button className="iconbtn" onClick={onExpandRail} data-tip={t('tavern_app.header.expand_rail')} aria-label={t('tavern_app.header.expand_rail')}>
           <Icon name="chevron_right" size={16} />
         </button>
       )}
@@ -248,12 +249,12 @@ function TavernHeader({ chat, character, persona, onOpenDrawer, onExport, onOpen
       )}
       <div className="tv-header-actions">
         {chat && onExport && (
-          <a className="iconbtn" href={onExport} target="_blank" rel="noopener" data-tip={t('tavern_app.header.export_jsonl')}>
+          <a className="iconbtn" href={onExport} target="_blank" rel="noopener" data-tip={t('tavern_app.header.export_jsonl')} aria-label={t('tavern_app.header.export_jsonl')}>
             <Icon name="download" size={15} />
           </a>
         )}
         {charName && (
-          <button className="iconbtn" onClick={onOpenDrawer} data-tip={t('tavern_app.header.char_persona')}>
+          <button className="iconbtn" onClick={onOpenDrawer} data-tip={t('tavern_app.header.char_persona')} aria-label={t('tavern_app.header.char_persona')}>
             <Icon name="cards" size={15} />
           </button>
         )}
@@ -516,7 +517,7 @@ export function TwoCardDrawer({ open, character, persona, onClose, onSavePersona
           <Icon name="settings" size={12} /> {t('tavern_app.drawer.tab_system')}
         </button>
       </div>
-      <button className="iconbtn" onClick={onClose} data-tip={inline ? t('tavern_app.drawer.collapse') : t('common.close')}>
+      <button className="iconbtn" onClick={onClose} data-tip={inline ? t('tavern_app.drawer.collapse') : t('common.close')} aria-label={inline ? t('tavern_app.drawer.collapse') : t('common.close')}>
         <Icon name={inline ? 'chevron_right' : 'close'} size={15} />
       </button>
     </header>


### PR DESCRIPTION
game-app.jsx (12 aria-label + 1 a->button):
- 折叠/新建/保存/分支/记忆模式(normal/deep/off)/复制/fork/重生成/删除/展开全部/分支图
- 加载更多历史 a[href] -> button

tavern-app.jsx (6 aria-label + onKeyDown):
- 菜单/移动导航/展开 rail/导出 JSONL/角色面板/抽屉关闭
- TavernChatItem div[role=button] 补 onKeyDown

branch-graph.jsx (3 aria-label):
- 继续/激活/删除

game-composer.jsx (2 aria-label + role/tabIndex/onKeyDown):
- 删除附件/关闭命令 chip
- ContextUsage span 补 role=button tabIndex=0 onKeyDown

game-panels.jsx (3 aria-label):
- 固定记忆/取消固定/添加关系

login-app.jsx (1 a->button):
- 忘记密码 a[href] -> button

platform-app.jsx (htmlFor+id + aria-label + a->button):
- PromptModal 表单 label htmlFor + 控件 id 关联
- 2 处搜索输入 aria-label
- 1 处 a->button