### PR TITLE
fix(docs): React 版本 18 -> 19 更正

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ RPG Roleplay drops a long-form novel into a self-hosted, LLM-driven RPG runtime:
 | **Python core game loop** (state, ops, scenes, dice, D&D 5E core, encounters, inventory, retrieval, agents) | ✅ Stable |
 | **LLM routing** (Anthropic native, OpenAI Responses, Vertex Gemini, OpenAI-compatible) | ✅ Stable, streaming + tool-use + multimodal |
 | **Postgres + pgvector storage**, v39+ versioned migrations, auto-apply on boot under advisory lock | ✅ Stable |
-| **Vite + React 18**, JSDoc type annotations, multi-page entries | ✅ Stable |
+| **Vite + React 19**, JSDoc type annotations, multi-page entries | ✅ Stable |
 | **Branchable saves** — commit / ref / checkout work like Git, hard-delete with 30-day grace queue | ✅ Stable |
 | **Script ingestion** — TXT / ZIP upload, 7 chapter splitters, auto-extract character cards + worldbook + timeline, vector index | ✅ Stable |
 | **SillyTavern V2/V3 import** — character cards (PNG tEXt / JSON) + chat history (JSONL → new save) | ✅ Stable |
@@ -138,7 +138,7 @@ You'll land on the Login page, create a user, then bounce to `Platform.html` (li
 
 ```
 ┌─ browser ──────────────────────────────────────────────────┐
-│  React 18 + Vite + JS (ESM multi-page)                     │
+│  React 19 + Vite + JS (ESM multi-page)                     │
 │  Login.html · Platform.html · Game Console.html            │
 │  Cloudscape Design System · api-client.js · i18n           │
 └───────────────────────────────┬────────────────────────────┘
@@ -191,7 +191,7 @@ Adding a provider = one entry in `rpg/config/model_catalog.json` + (if a new wir
 
 ## Stack
 
-`Python 3.12+` · `FastAPI` · `uvicorn` · `psycopg` · `pgvector` · `pgbouncer` · `Redis` · `React 18` · `Vite` · `Cloudscape Design System`
+`Python 3.12+` · `FastAPI` · `uvicorn` · `psycopg` · `pgvector` · `pgbouncer` · `Redis` · `React 19` · `Vite` · `Cloudscape Design System`
 
 ## Why not SillyTavern / Risu / KoboldCpp?
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,7 @@ RPG Roleplay 把一本长篇小说扔进一个自托管的 LLM 驱动的 RPG 运
 | **Python 核心游戏循环**(state, op, scene, 骰子, 5E 核心, 遭遇, 物品栏, 检索, agents) | ✅ 稳定 |
 | **LLM 路由**(Anthropic 原生 / OpenAI Responses / Vertex Gemini / OpenAI 兼容) | ✅ 稳定 — 流式 + 工具调用 + 多模态 |
 | **Postgres + pgvector** 存储, v39+ 版本化迁移, 启动时自动加咨询锁顺序执行 | ✅ 稳定 |
-| **Vite + React 18**, JSDoc 类型注解, 多页面入口 | ✅ 稳定 |
+| **Vite + React 19**, JSDoc 类型注解, 多页面入口 | ✅ 稳定 |
 | **可分支存档** — commit / ref / checkout 像 Git 一样工作 + 硬删 30 天宽限队列 | ✅ 稳定 |
 | **剧本导入** — TXT / ZIP 上传, 7 种章节切分, 自动抽角色卡 + 世界书 + 时间线 + 向量索引 | ✅ 稳定 |
 | **SillyTavern V2/V3 导入** — 角色卡(PNG tEXt / JSON) + 聊天记录(JSONL → 新存档) | ✅ 稳定 |
@@ -138,7 +138,7 @@ open http://localhost:5173/Login.html
 
 ```
 ┌─ browser ──────────────────────────────────────────────────┐
-│  React 18 + Vite + JS (ESM multi-page)                     │
+│  React 19 + Vite + JS (ESM multi-page)                     │
 │  Login.html · Platform.html · Game Console.html            │
 │  Cloudscape Design System · api-client.js · i18n           │
 └───────────────────────────────┬────────────────────────────┘
@@ -191,7 +191,7 @@ FastAPI 后端，~30+ 个路由模块 / agents / state mixin，~1k pytest 用例
 
 ## 技术栈
 
-`Python 3.12+` · `FastAPI` · `uvicorn` · `psycopg` · `pgvector` · `pgbouncer` · `Redis` · `React 18` · `Vite` · `Cloudscape Design System`
+`Python 3.12+` · `FastAPI` · `uvicorn` · `psycopg` · `pgvector` · `pgbouncer` · `Redis` · `React 19` · `Vite` · `Cloudscape Design System`
 
 ## 为什么不是 SillyTavern / Risu / KoboldCpp?
 


### PR DESCRIPTION
- 状态表 (1 处/文件)
- 架构图 ASCII (1 处/文件)
- 技术栈段落 (1 处/文件) 共 6 处,与 package.json react@19.2.7 一致