### PR TITLE
fix(css): overscroll-behavior + safe-area-inset + focus-visible 焦点环

### DIFF
--- a/frontend/src/game-console.css
+++ b/frontend/src/game-console.css
@@ -348,6 +348,7 @@
   justify-content: space-between;
   gap: 12px;
   padding: 0 18px;
+  padding-top: env(safe-area-inset-top, 0px);
   height: 64px;
   border-bottom: 1px solid var(--line-soft);
   background: rgba(26, 24, 23, 0.92);
@@ -783,7 +784,7 @@
 .gc-float-panel-btn {
   display: none;
   position: fixed;
-  bottom: 80px;
+  bottom: calc(80px + env(safe-area-inset-bottom, 0px));
   right: 16px;
   width: 40px; height: 40px;
   border-radius: 999px;
@@ -890,6 +891,7 @@
 .gc-menu > .gc-menu-head { flex-shrink: 0; }
 .gc-menu > .gc-menu-foot { flex-shrink: 0; }
 .gc-menu > ul.gc-pop-list {
+  overscroll-behavior: contain;
   flex: 1;
   overflow-y: auto;
   min-height: 0;
@@ -1538,6 +1540,7 @@
     height: 88vh !important; max-height: 88vh;
     z-index: 500;
     border-radius: 18px 18px 0 0;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
     border-left: none;
     border-top: 1px solid var(--line);
     transform: translateY(100%);            /* 收起:滑到屏幕下方 */
@@ -1605,6 +1608,7 @@
     background: rgba(0, 0, 0, 0.45);
     backdrop-filter: blur(2px);
     -webkit-backdrop-filter: blur(2px);
+    overscroll-behavior: contain;
   }
 
   .gp-panel-resize-handle { display: none; }
@@ -1654,6 +1658,7 @@
     background: rgba(0, 0, 0, 0.45);
     backdrop-filter: blur(1px);
     -webkit-backdrop-filter: blur(1px);
+    overscroll-behavior: contain;
   }
 }
 @media (max-width: 720px) {

--- a/frontend/src/media.css
+++ b/frontend/src/media.css
@@ -169,7 +169,7 @@
 }
 
 /* 精致 lightbox（覆盖 AvatarImg 内置的，可全局用）*/
-.mlb-backdrop { position: fixed; inset: 0; z-index: 9000; background: rgba(10,9,8,.9); display: flex; align-items: center; justify-content: center; animation: mlb-fade .2s ease; }
+.mlb-backdrop { position: fixed; inset: 0; z-index: 9000; background: rgba(10,9,8,.9); display: flex; align-items: center; justify-content: center; animation: mlb-fade .2s ease; overscroll-behavior: contain; }
 @keyframes mlb-fade { from { opacity: 0; } to { opacity: 1; } }
 
 /* ── 触屏：无 hover，悬停才浮现的控件改为常驻可见 ────────────── */
@@ -244,6 +244,7 @@
   background: rgba(10, 9, 8, .92);
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 14px; padding: 24px; animation: mlb-fade .18s ease;
+  overscroll-behavior: contain;
 }
 .ilb__stage { display: flex; flex-direction: column; align-items: center; gap: 14px; max-width: 96vw; }
 .ilb__imgwrap { position: relative; display: inline-block; line-height: 0; }
@@ -284,7 +285,7 @@
 .ilb__btn:disabled { opacity: .6; cursor: not-allowed; }
 .ilb__btn--ghost { background: rgba(255,255,255,.12); color: #f3efe8; }
 .ilb__close {
-  position: absolute; top: 20px; right: 24px; width: 40px; height: 40px; z-index: 3;
+  position: absolute; top: calc(20px + env(safe-area-inset-top, 0px)); right: calc(24px + env(safe-area-inset-right, 0px)); width: 40px; height: 40px; z-index: 3;
   border-radius: 99px; border: 0; background: rgba(255,255,255,.14); color: #fff;
   font-size: 21px; cursor: pointer; line-height: 1;
 }

--- a/frontend/src/mobile.css
+++ b/frontend/src/mobile.css
@@ -317,6 +317,7 @@ html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
   color: var(--text); padding: 9px 2px; max-height: 120px;
   outline: none;
 }
+.m-root .c-text:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .m-root .c-text::placeholder { color: var(--muted-2); font-family: var(--font-serif); }
 .m-root .c-send {
   width: 38px; height: 38px; flex: none;
@@ -588,8 +589,8 @@ html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
 .m-root .stat { border: 1px solid var(--line-soft); border-radius: 9px; padding: 9px 4px; text-align: center; background: var(--panel); }
 .m-root .stat .n { font: 600 17px var(--font-serif); display: block; }
 .m-root .stat .l { font-size: 9.5px; color: var(--muted-2); margin-top: 2px; }
-.m-root .sheet-wrap { position: absolute; inset: 0; z-index: 60; pointer-events: none; }
-.m-root .sheet-scrim { position: absolute; inset: 0; background: rgba(10,9,8,0.5); opacity: 0; transition: opacity .28s var(--ease); }
+.m-root .sheet-wrap { position: absolute; inset: 0; z-index: 60; pointer-events: none; overscroll-behavior: contain; }
+.m-root .sheet-scrim { position: absolute; inset: 0; background: rgba(10,9,8,0.5); opacity: 0; transition: opacity .28s var(--ease); overscroll-behavior: contain; }
 .m-root .sheet-wrap.show { pointer-events: auto; }
 .m-root .sheet-wrap.show .sheet-scrim { opacity: 1; }
 .m-root .sheet {
@@ -863,6 +864,7 @@ html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
   border-radius: 12px; border: 1px solid var(--line-soft); background: var(--panel); color: var(--muted);
 }
 .m-root .pl-search input { flex: 1; border: 0; background: transparent; color: var(--text); font: 13.5px var(--font-sans); outline: none; }
+.m-root .pl-search input:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .m-root .pl-search input::placeholder { color: var(--muted-2); }
 .m-root .pl-seg-scroll { display: flex; gap: 7px; overflow-x: auto; padding: 2px 16px 12px; -webkit-overflow-scrolling: touch; }
 .m-root .pl-seg-scroll::-webkit-scrollbar { display: none; }
@@ -900,6 +902,7 @@ html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
   color: var(--text); font: 14.5px var(--font-sans); padding: 0 14px; outline: none; width: 100%;
   transition: border-color .15s, box-shadow .15s;
 }
+.m-root .pl-input:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .m-root .pl-input:focus { border-color: var(--accent-edge); box-shadow: 0 0 0 3px rgba(201,100,66,0.08); }
 .m-root .pl-input::placeholder { color: var(--muted-2); }
 .m-root textarea.pl-input { height: auto; min-height: 92px; padding: 12px 14px; resize: none; line-height: 1.6; }
@@ -922,6 +925,7 @@ html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
 .m-root .pl-slider-head .lab { font-size: 13.5px; color: var(--text); }
 .m-root .pl-slider-head .val { font: 600 13px var(--font-mono); color: var(--accent); }
 .m-root .pl-slider { -webkit-appearance: none; appearance: none; width: 100%; height: 5px; border-radius: 3px; background: var(--panel-3); outline: none; }
+.m-root .pl-slider:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .m-root .pl-slider::-webkit-slider-thumb { -webkit-appearance: none; width: 22px; height: 22px; border-radius: 999px; background: var(--accent); border: 3px solid var(--bg); box-shadow: 0 1px 4px rgba(0,0,0,0.4); cursor: pointer; }
 .m-root .pl-slider::-moz-range-thumb { width: 18px; height: 18px; border-radius: 999px; background: var(--accent); border: 3px solid var(--bg); }
 .m-root .pl-slider-desc { font-size: 11px; color: var(--muted-2); margin-top: 7px; line-height: 1.5; }
@@ -1050,7 +1054,7 @@ html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
 .m-root .ih-wrap { position: relative; display: inline-flex; vertical-align: middle; }
 .m-root .ih-btn { width: 18px; height: 18px; flex: none; display: grid; place-items: center; border-radius: 999px; color: var(--muted-2); border: 1px solid var(--line); background: var(--panel-2); transition: color .14s, border-color .14s; }
 .m-root .ih-btn:active { color: var(--accent); border-color: var(--accent-edge); }
-.m-root .ih-scrim { position: fixed; inset: 0; z-index: 70; }
+.m-root .ih-scrim { position: fixed; inset: 0; z-index: 70; overscroll-behavior: contain; }
 .m-root .ih-pop {
   position: absolute; top: calc(100% + 7px); left: 0; z-index: 71;
   width: max-content; max-width: 240px;
@@ -1288,6 +1292,7 @@ html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
   padding: 4px 0; line-height: 1.6; color: var(--text); outline: none;
   min-height: 32px; max-height: 220px; overflow-y: auto;
 }
+.m-root .tavern-chat .gc-textarea:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .m-root .tavern-chat .gc-textarea.serif { font-family: var(--font-serif); font-size: 15.5px; line-height: 1.78; letter-spacing: 0.02em; }
 .m-root .tavern-chat .gc-textarea::placeholder { color: var(--muted-2); font-family: var(--font-serif); }
 .m-root .tavern-chat .gc-composer.writing .gc-textarea { min-height: 72px; }
@@ -1309,9 +1314,9 @@ html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
 .m-root .tavern-chat .btn.primary:disabled { opacity: 0.45; pointer-events: none; }
 .m-root .tavern-chat .btn.danger { background: transparent; border-color: rgba(200,103,93,0.35); color: var(--danger); }
 .m-root .tavern-chat .btn.danger:hover { background: var(--danger-soft); }
-.m-root .tv-sheet-wrap { position: absolute; inset: 0; z-index: 120; pointer-events: none; }
+.m-root .tv-sheet-wrap { position: absolute; inset: 0; z-index: 120; pointer-events: none; overscroll-behavior: contain; }
 .m-root .tv-sheet-wrap.show { pointer-events: auto; }
-.m-root .tv-sheet-scrim { position: absolute; inset: 0; background: rgba(8,7,6,0.62); opacity: 0; transition: opacity .3s; }
+.m-root .tv-sheet-scrim { position: absolute; inset: 0; background: rgba(8,7,6,0.62); opacity: 0; transition: opacity .3s; overscroll-behavior: contain; }
 .m-root .tv-sheet-wrap.show .tv-sheet-scrim { opacity: 1; }
 .m-root .tv-sheet {
   position: absolute; left: 0; right: 0; bottom: 0; max-height: 86%;
@@ -1385,6 +1390,7 @@ html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
   font-family: var(--font-sans); font-size: 13.5px; line-height: 1.55; outline: none;
   transition: border-color .15s, background .15s;
 }
+.m-root .tv-input:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .m-root textarea.tv-input { resize: none; font-family: var(--font-serif); }
 .m-root .tv-input:focus { border-color: var(--accent-edge); background: var(--panel); }
 .m-root .tv-pedit-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 16px; }
@@ -1583,6 +1589,7 @@ html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
 
 /* ─ 通用输入框 ─ */
 .m-root .tv-m-input { width: 100%; padding: 11px 13px; border-radius: 12px; border: 1px solid var(--line); background: var(--bg-deep); color: var(--text); font: 14.5px/1.6 var(--font-serif); outline: none; }
+.m-root .tv-m-input:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .m-root .tv-m-input:focus { border-color: var(--accent-edge); box-shadow: 0 0 0 3px rgba(201,100,66,0.07); }
 .m-root textarea.tv-m-input { resize: none; }
 /* P5 新游戏向导 spin */

--- a/frontend/src/pages/md-editor.css
+++ b/frontend/src/pages/md-editor.css
@@ -244,6 +244,7 @@
 .mde-tree:focus-visible { outline: 1px solid var(--accent, #b5654a); outline-offset: -2px; }
 .mde-tree-toolbar { display: flex; align-items: center; gap: 4px; padding: 6px 8px; border-bottom: 1px solid var(--line-soft, #2a2724); }
 .mde-tree-filter { flex: 1 1 auto; min-width: 0; padding: 4px 8px; background: rgba(255,255,255,0.04); border: 1px solid var(--line-soft, #2a2724); border-radius: 6px; color: var(--text, #ebe7df); font-size: 12px; outline: none; font-family: inherit; }
+.mde-tree-filter:focus-visible { outline: 2px solid var(--accent, #b5654a); outline-offset: 1px; }
 .mde-tree-filter::placeholder { color: var(--muted-2, #6b655e); }
 .mde-tree-tbbtn { flex: 0 0 auto; width: 24px; height: 24px; display: inline-flex; align-items: center; justify-content: center; background: transparent; border: 1px solid transparent; border-radius: 5px; color: var(--muted, #968f85); cursor: pointer; font-size: 13px; line-height: 1; }
 .mde-tree-tbbtn:hover { background: var(--panel-2, #282623); color: var(--text, #ebe7df); border-color: var(--line, #36322d); }
@@ -259,6 +260,7 @@
 .mde-tree-item.active .mde-tree-iicon, .mde-tree-item.sel .mde-tree-iicon { color: var(--accent, #b5654a); }
 .mde-tree-item.dragging { opacity: 0.45; }
 .mde-tree-edit { width: calc(100% - 4px); margin: 1px 2px; padding: 3px 8px; background: var(--bg-deep, #131211); border: 1px solid var(--accent, #b5654a); border-radius: 5px; color: var(--text, #ebe7df); font-size: 12px; outline: none; font-family: inherit; box-sizing: border-box; }
+.mde-tree-edit:focus-visible { outline: 2px solid var(--accent, #b5654a); outline-offset: 1px; }
 .mde-ctx { position: fixed; z-index: 3000; min-width: 132px; background: var(--panel, #211f1d); border: 1px solid var(--line, #36322d); border-radius: 7px; box-shadow: 0 8px 28px rgba(0,0,0,.5); padding: 4px; display: flex; flex-direction: column; }
 .mde-ctx button { text-align: left; background: transparent; border: none; color: var(--text, #ebe7df); padding: 6px 10px; font-size: 12.5px; cursor: pointer; border-radius: 5px; font-family: inherit; }
 .mde-ctx button:hover:not(:disabled) { background: var(--panel-2, #282623); }

--- a/frontend/src/platform.css
+++ b/frontend/src/platform.css
@@ -322,6 +322,7 @@ button, a, [role="button"], .btn, .iconbtn, summary, label {
   position: sticky; top: 0; z-index: 3;
   display: flex; align-items: center; justify-content: space-between; gap: 12px;
   padding: 0 24px;
+  padding-top: env(safe-area-inset-top, 0px);
   height: 72px;
   flex-shrink: 0;
   border-bottom: 1px solid var(--line-soft);
@@ -561,7 +562,7 @@ button, a, [role="button"], .btn, .iconbtn, summary, label {
   position: fixed;
   /* 顶栏 #pl-cs-topnav 高 ~53px / z-index 1002:toast 必须落在它下方且层级更高,
      否则通知框被顶栏遮盖。 */
-  top: 64px;
+  top: calc(64px + env(safe-area-inset-top, 0px));
   left: 50%;
   transform: translateX(-50%);
   z-index: 1100;
@@ -1986,6 +1987,7 @@ button, a, [role="button"], .btn, .iconbtn, summary, label {
   z-index: 50;
   padding: 24px;
   transition: right 0.2s cubic-bezier(.2,.7,.2,1);
+  overscroll-behavior: contain;
 }
 .pl-modal {
   width: min(560px, 100%);

--- a/frontend/src/tavern.css
+++ b/frontend/src/tavern.css
@@ -149,6 +149,7 @@
   border: 1px solid var(--accent); border-radius: 5px;
   padding: 1px 6px; outline: none; font-family: inherit;
 }
+.tv-chat-title-edit:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .tv-chat-time { font-size: 10.5px; flex-shrink: 0; }
 .tv-chat-snippet {
   font-size: 11.5px; margin-top: 2px;
@@ -160,7 +161,7 @@
 .tv-chat-menu-btn { opacity: 0; width: 24px; height: 24px; }
 .tv-chat-item:hover .tv-chat-menu-btn,
 .tv-chat-item:focus-within .tv-chat-menu-btn { opacity: 1; }
-.tv-menu-scrim { position: fixed; inset: 0; z-index: 1499; }
+.tv-menu-scrim { position: fixed; inset: 0; z-index: 1499; overscroll-behavior: contain; }
 .tv-menu {
   position: absolute; top: 100%; right: 0; z-index: 1500; margin-top: 2px;
   background: var(--panel); border: 1px solid var(--line-soft);
@@ -255,6 +256,7 @@
   position: fixed; inset: 0; z-index: 2000;
   background: rgba(0,0,0,0.5);
   display: flex; justify-content: flex-end;
+  overscroll-behavior: contain;
 }
 .tv-drawer {
   width: min(560px, 100vw);


### PR DESCRIPTION
overscroll-behavior: contain (13 处):
- tavern.css: tv-drawer-backdrop, tv-menu-scrim
- media.css: mlb-backdrop, ilb
- platform.css: pl-modal-backdrop
- game-console.css: gc-panel-backdrop, gc-nav-backdrop, gc-pop-list
- mobile.css: sheet-wrap, sheet-scrim, ih-scrim, tv-sheet-wrap, tv-sheet-scrim

safe-area-inset (6 处):
- platform.css: pl-topbar, pl-toast-stack
- game-console.css: gc-topbar, gc-float-panel-btn, @media gp-panel
- media.css: ilb__close

outline:none -> focus-visible 焦点环 (10 处):
- focus-visible { outline: 2px solid var(--accent); outline-offset: 1px }
- tavern.css: tv-chat-title-edit
- mobile.css: c-text, pl-search input, pl-input, pl-slider, gc-textarea, tv-input, tv-m-input
- md-editor.css: mde-tree-filter, mde-tree-edit