### PR TITLE
fix(branches): 切分支/新建分支时截断旧 messages + opening 不写空 user 行

### DIFF
--- a/rpg/platform_app/branches/activation.py
+++ b/rpg/platform_app/branches/activation.py
@@ -47,6 +47,13 @@ def continue_from(user_id: int, node_id: int) -> dict[str, Any]:
         ref_row = ref
         _set_save_active(db, save_id, active_commit_id, active_ref_id)
         _write_checkout(db, user_id, save_id, active_ref_id, active_commit_id)
+        # 截断超出目标 commit turn 的 messages:新建分支后旧分支残留的消息
+        # 会被 materialize() 重建 history 时拉出来,导致 Game Console 显示旧分支对话。
+        target_turn = int(node.get("turn_index") or 0)
+        db.execute(
+            "delete from messages where save_id = %s and turn > %s",
+            (save_id, target_turn),
+        )
     # [hotfix] runtime 写必须在 with 块外(advisory 锁已释放 + 本 conn 已归还池)。
     # 原来锁内调 activate_state_snapshot → _db_write_runtime 会【另开一条 conn】去
     # `update game_saves set last_played_at where id=save_id`,而本事务未提交的 _set_save_active
@@ -80,6 +87,12 @@ def activate_node(user_id: int, node_id: int) -> dict[str, Any]:
         state_path = node["state_path"]
         state_snapshot = commit_state(node)
         active_ref_id = ref["id"]
+        # 截断超出目标 commit turn 的 messages(与 continue_from 同理)。
+        target_turn = int(node.get("turn_index") or 0)
+        db.execute(
+            "delete from messages where save_id = %s and turn > %s",
+            (save_id, target_turn),
+        )
     # [hotfix] runtime 写移出 with 块,避免锁内嵌套连接 update 同一 game_saves 行的自死锁(见 continue_from)。
     runtime_info = _runtime_module.activate_state_snapshot(user_id, save_id, node_id, state_snapshot, state_path, ref_id=active_ref_id)
     result = tree(user_id, save_id)

--- a/rpg/platform_app/knowledge/_context_runs_repo.py
+++ b/rpg/platform_app/knowledge/_context_runs_repo.py
@@ -21,15 +21,21 @@ def _db_update_context_run_status(db, run_id: int, status: str, error: str, dura
 
 
 def _db_insert_turn_messages(db, session_id: int, save_id: int, turn: int, player_input: str, gm_output: str, metadata: dict[str, Any]) -> tuple:
-    """repository: 插入一对 user/assistant 消息，返回 (user_row, gm_row)。"""
-    user_msg = db.execute(
-        """
-        insert into messages(session_id, save_id, turn, role, content, metadata)
-        values (%s, %s, %s, 'user', %s, %s)
-        returning *
-        """,
-        (session_id, save_id, turn, player_input, Jsonb(metadata)),
-    ).fetchone()
+    """repository: 插入一对 user/assistant 消息，返回 (user_row, gm_row)。
+
+    opening 等无真实玩家输入的场景,player_input 为空 → 跳过 user 行,
+    避免 materialize() 重建 history 时出现空的玩家气泡。
+    """
+    user_msg = None
+    if player_input and player_input.strip():
+        user_msg = db.execute(
+            """
+            insert into messages(session_id, save_id, turn, role, content, metadata)
+            values (%s, %s, %s, 'user', %s, %s)
+            returning *
+            """,
+            (session_id, save_id, turn, player_input, Jsonb(metadata)),
+        ).fetchone()
     gm_msg = db.execute(
         """
         insert into messages(session_id, save_id, turn, role, content, metadata)


### PR DESCRIPTION
## 修复内容

### Bug 1: 切分支后显示旧分支的对话消息

**根因**: `continue_from()` 和 `activate_node()` 切换分支指针时，只更新了 `game_saves` 的 `active_commit_id` 和 `active_ref_id`，但没有截断 `messages` 表中超出目标 commit `turn_index` 的消息行。

`messages` 表按 `save_id` 存储（无 `branch_id` 列），`materialize()` 查询 `messages WHERE save_id = %s ORDER BY turn, id` 时拉出了旧分支的所有消息，前端渲染出不属于当前分支的对话。

**修复**: 在 `continue_from()` 和 `activate_node()` 的事务块内，指针切换后添加：
```python
target_turn = int(node.get("turn_index") or 0)
db.execute(
    "delete from messages where save_id = %s and turn > %s",
    (save_id, target_turn),
)
```

### Bug 2: Opening 流程写入空 user 消息

**根因**: `rpg/routes/game.py` opening 流程调用 `record_turn_messages(..., "", ...)` 时 `player_input=""` 被无条件写入 messages 表的 `user` 行。`materialize()` 重建 history 时出现空玩家气泡。

**修复**: `_db_insert_turn_messages` 中当 `player_input` 为空或纯空白时跳过 user 行 INSERT。

## 修改文件

- `rpg/platform_app/branches/activation.py` — continue_from / activate_node 添加 messages 截断
- `rpg/platform_app/knowledge/_context_runs_repo.py` — _db_insert_turn_messages 跳过空输入