### PR TITLE
fix: add logging to silent except Exception blocks

### DIFF
--- a/rpg/app.py
+++ b/rpg/app.py
@@ -637,6 +637,9 @@ def _stop_user(api_user: dict[str, Any] | None) -> None:
             ev.set()
     # 跨进程：写 DB stop_signals
     if api_user:
+        # current_run 必须在 try **之外**先绑定:否则 import 那行抛异常时它还没赋值,
+        # except 里引用它会抛 UnboundLocalError —— 把本来被吞掉的错误升级成真崩溃。
+        current_run = 0
         try:
             from platform_app.cluster import request_stop
             current_run = _lru_get(_run_id_by_user, uid, 0)
@@ -2432,6 +2435,10 @@ def _resolve_console_assistant_backend(api_user: dict[str, Any] | None):
     # BYOK 守卫(同主 GM):解析出的 provider 用户不可用(stale 偏好/默认落 vertex 但没 SA)
     # → 回退到用户配过 key 的第一个模型,避免控制台助手构造即失败。
     if api_user and api_user.get("id"):
+        # 同 _stop_user:日志引用的变量必须在 try 之外先绑定。int(api_user["id"]) 本身
+        # 就可能抛(脏 session / 非数字 id),那时 _uid_c 尚未赋值,except 里引用它会
+        # UnboundLocalError —— 反而把被吞的错误变成崩溃。
+        _uid_c = api_user.get("id")
         try:
             _uid_c = int(api_user["id"])
             from core.llm_backend import guard_byok_usable as _guard_byok_c

--- a/rpg/app.py
+++ b/rpg/app.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import base64
 import binascii
 import json
-import os
 import re
 import shutil
 import sys
@@ -46,7 +45,6 @@ from core.startup import configure_app, lifespan
 from model_registry import (
     delete_model,  # noqa: F401
     load_catalog_for_user,
-    load_model_catalog,
     select_model,  # noqa: F401
     selected_model,
     upsert_api,  # noqa: F401
@@ -238,6 +236,7 @@ def _verify_acceptance(
 # P0-3: 单请求用户偏好缓存 — 用 request_id contextvar 做 key,同一请求内只查一次 DB。
 # cache 在请求结束后由 api_chat/api_opening 调用 _clear_prefs_cache 清理。
 import contextvars as _contextvars
+
 _prefs_cache_var: _contextvars.ContextVar[dict] = _contextvars.ContextVar(
     "_prefs_cache", default=None  # type: ignore[assignment]
 )
@@ -264,7 +263,7 @@ def _get_user_preferences_cached(api_user: dict | None) -> dict:
         if row and isinstance(row.get("preferences"), dict):
             prefs = row["preferences"]
     except Exception:
-        pass
+        log.warning("[prefs] load_preferences DB 查询失败,回退空偏好 uid=%s", uid, exc_info=True)
     cache = {"__uid__": uid, **prefs}
     _prefs_cache_var.set(cache)
     return cache
@@ -459,14 +458,14 @@ from routes.console_assistant import router as console_assistant_router
 from routes.game import router as game_router
 from routes.mcp import router as mcp_router
 from routes.models import router as models_router
+from routes.persona_skills import router as persona_skills_router
 from routes.rath import router as rath_router
+from routes.regex_scripts import router as regex_scripts_router
 from routes.rules import router as rules_router
 from routes.sidebar import router as sidebar_router
 from routes.skills import router as skills_router
-from routes.persona_skills import router as persona_skills_router
 from routes.tavern import router as tavern_router
 from routes.timeline import router as timeline_router
-from routes.regex_scripts import router as regex_scripts_router
 from routes.worldbook_overlay import router as worldbook_overlay_router
 from routes.worldline import router as worldline_router
 
@@ -546,7 +545,9 @@ if _FRONTEND_DIR.is_dir():
 
 # 注：init_db 已移到 core.startup.lifespan startup 段（lazy import 避免循环依赖）。
 # 此处保留函数引用，供 lifespan 使用。
-from platform_app.db import init_db as _bootstrap_init_db  # noqa: F401  (lifespan lazy-imports this)
+from platform_app.db import (
+    init_db as _bootstrap_init_db,  # noqa: F401  (lifespan lazy-imports this)
+)
 
 _startup_auth_banner()
 
@@ -584,7 +585,7 @@ _state_save_id_by_user: OrderedDict[int, int] = OrderedDict()
 _state_commit_id_by_user: OrderedDict[int, int] = OrderedDict()
 # 侧改漂移检测:out-of-turn 编辑(固定记忆/笔记增删等)bump runtime snapshot_hash 但不 bump
 # commit → 记本 worker 载入时的 snapshot_hash,与 DB 真值比对抓跨 worker 陈旧缓存。
-_state_snaphash_by_user: "OrderedDict[int, str]" = OrderedDict()
+_state_snaphash_by_user: OrderedDict[int, str] = OrderedDict()
 _gm_by_user: OrderedDict[int, GameMaster] = OrderedDict()
 # B4: 子代理使用独立 GameMaster 实例，独立模型 / 独立 usage / 独立日志
 _sub_gm_by_user: OrderedDict[int, GameMaster] = OrderedDict()
@@ -642,7 +643,7 @@ def _stop_user(api_user: dict[str, Any] | None) -> None:
             if current_run:
                 request_stop(int(api_user["id"]), current_run)
         except Exception:
-            pass
+            log.warning("[stop] request_stop 失败 uid=%s run_id=%s", uid, current_run, exc_info=True)
 
 
 def _is_stop_requested_global(api_user: dict[str, Any] | None, run_id: int) -> bool:
@@ -739,7 +740,7 @@ def _selfheal_player_from_save_snapshot(state: GameState, api_user: dict[str, An
         })
         state.data["permissions"]["audit_log"] = audit[-200:]
     except Exception:
-        pass
+        log.warning("[state] 快照恢复玩家状态失败,fallback 空 player", exc_info=True)
 
 
 def _kb_state_enabled(api_user: dict | None = None) -> bool:
@@ -769,7 +770,7 @@ def _save_kb_native(save_id: int | None) -> bool:
         return False
 
 
-def _kb_backed_state(state: "GameState", save_id: int, commit_id: int) -> "GameState":
+def _kb_backed_state(state: GameState, save_id: int, commit_id: int) -> GameState:
     """从 KB 表 materialize 出 GameState(而非读 blob)。首次加载该 save 且 KB 未 seed →
     先把当前 blob 迁进 KB(T0 seed 实体 + import_state)再 materialize(migrate-on-first-load)。"""
     from kb import save_kb
@@ -1138,7 +1139,11 @@ def _resolve_user_default_model_view(api_user: dict[str, Any] | None, model_cata
     try:
         from core.llm_backend import (
             first_user_model as _fum,
+        )
+        from core.llm_backend import (
             resolve_preferred_api as _rpa,
+        )
+        from core.llm_backend import (
             resolve_preferred_model as _rpm,
         )
         _api = _rpa(uid, "gm.api_id")
@@ -1150,7 +1155,7 @@ def _resolve_user_default_model_view(api_user: dict[str, Any] | None, model_cata
         if _api and _mdl:
             return _session_model_app_view(model_catalog, (_mdl, _api))
     except Exception:
-        pass
+        log.warning("[models] _session_model_app_view 失败 uid=%s", uid, exc_info=True)
     return None
 
 
@@ -1169,7 +1174,7 @@ def _resolve_effective_model_view(api_user: dict[str, Any] | None, model_catalog
             if _sess_view:
                 return _sess_view
     except Exception:
-        pass
+        log.warning("[models] _resolve_effective_model_view 失败,回退默认模型视图", exc_info=True)
     return _resolve_user_default_model_view(api_user, model_catalog)
 
 
@@ -1279,7 +1284,7 @@ def _payload(api_user: dict[str, Any] | None = None, *, include_catalog: bool = 
                 "real_name": model["real_name"],
             }
         except Exception:
-            pass
+            log.warning("[payload] models.selected 设置失败", exc_info=True)
         payload["tools"] = _redact_tools(tool_payload(), is_admin)
     # task 10：把当前激活存档的 id/title 直接挂在 /api/state 顶层 + state 字段里，
     # Game Console 左侧栏拿来显示「当前存档」，避免回退到 hard-coded mock id=11。
@@ -1324,7 +1329,7 @@ def _user_credentialed_api_ids(user_id: int | None) -> set[str]:
             if it.get("has_credential") and it.get("enabled"):
                 ids.add(normalize_api_id(it.get("api_id")))
     except Exception:
-        pass
+        log.warning("[state] list_credentials 失败 user_id=%s", user_id, exc_info=True)
     try:
         from core.vertex_sa import has_user_sa
         if has_user_sa(int(user_id)):
@@ -1343,13 +1348,15 @@ def _redact_catalog(catalog: dict[str, Any], is_admin: bool, user_id: int | None
     服务器模式必须传 user_id;本地匿名模式回退到 env/SA 文件存在性。
     """
     import copy
+
     import model_probe
-    from model_registry import normalize_api_id
+
     # require_auth() 现已 mode-aware(server 模式 → True),统一按 per-user 账号 key 算 has_credential;
     # 注意:不论 require_auth 与否,只要能解析出 user_id 就按用户 BYOK 算。
     # 旧版 "if require_auth" 守卫会让 local 模式 + api_user=user 1 走 else(env/SA),
     # 而 env/SA 在 local 模式几乎都是空的 → has_credential 全部 false。
     from core.config import require_auth as _require_auth
+    from model_registry import normalize_api_id
     result = copy.deepcopy(catalog)
     require_auth = _require_auth()
     cred_ids = _user_credentialed_api_ids(user_id) if user_id is not None else set()
@@ -1581,7 +1588,7 @@ def _mark_context_run(context_run_id: int | None, status: str, error: str = "", 
             duration_ms=duration_ms,
         )
     except Exception:
-        pass
+        log.warning("[context_run] update_context_run_status 失败 run_id=%s", context_run_id, exc_info=True)
 
 
 def _persist_runtime_checkpoint(state: GameState, user: dict[str, Any] | None) -> None:
@@ -1852,13 +1859,13 @@ from rules_bridge import (
     parse_pickup_intent as _rb_parse_pickup_intent,
 )
 from rules_bridge import (
-    pickup_loot_action as _rb_pickup_loot_action,
-)
-from rules_bridge import (
     perform_saving_throw as _rb_saving_throw,
 )
 from rules_bridge import (
     perform_skill_check as _rb_skill_check,
+)
+from rules_bridge import (
+    pickup_loot_action as _rb_pickup_loot_action,
 )
 from rules_bridge import (
     player_attack as _rb_player_attack,
@@ -2407,12 +2414,13 @@ def _resolve_console_assistant_backend(api_user: dict[str, Any] | None):
                     if not model_real:
                         model_real = prefs.get("gm.model_real_name") or None
         except Exception:
-            pass
+            log.warning("[console] console_assistant_model_override 读取失败", exc_info=True)
     if not api_id or not model_real:
         try:
             from core.llm_backend import first_user_model
             user_default = first_user_model(int(api_user["id"])) if api_user and api_user.get("id") else None
         except Exception:
+            log.warning("[console] first_user_model 失败", exc_info=True)
             user_default = None
         if user_default:
             api_id = api_id or user_default[0]
@@ -2429,7 +2437,7 @@ def _resolve_console_assistant_backend(api_user: dict[str, Any] | None):
             from core.llm_backend import guard_byok_usable as _guard_byok_c
             api_id, model_real = _guard_byok_c(_uid_c, api_id, model_real)
         except Exception:
-            pass
+            log.warning("[console] guard_byok_usable 失败 uid=%s", _uid_c, exc_info=True)
     # 用 GameMaster 构造 backend, 再借用其 ._backend
     gm = GameMaster(
         api_id=str(api_id) if api_id is not None else api_id,

--- a/rpg/mcp_broker.py
+++ b/rpg/mcp_broker.py
@@ -136,7 +136,10 @@ class MCPServerConn:
             except subprocess.TimeoutExpired:
                 self.proc.kill()
         except Exception:
-            pass
+            import logging
+            logging.getLogger("rpg.mcp_broker").warning(
+                "[mcp] terminate/kill 失败 server_id=%s", self.server_id, exc_info=True
+            )
         self.proc = None
         with self._pending_lock:
             self._pending_lock.notify_all()
@@ -156,7 +159,10 @@ class MCPServerConn:
                 result = self._request("tools/list", {}, timeout=timeout)
                 self.tools = result.get("tools") or []
             except Exception:
-                pass
+                import logging
+                logging.getLogger("rpg.mcp_broker").warning(
+                    "[mcp] tools/list 刷新失败 server_id=%s", self.server_id, exc_info=True
+                )
         return self.tools
 
     # ── 内部：JSON-RPC ────────────────────────────────────────────
@@ -430,7 +436,10 @@ def _health_loop():
                         except Exception:
                             conn._health = "restart_failed"
         except Exception:
-            pass
+            import logging
+            logging.getLogger("rpg.mcp_broker").warning(
+                "[mcp] health loop 异常,等待 %ss 后重试", HEALTH_CHECK_INTERVAL, exc_info=True
+            )
         _HEALTH_STOP.wait(HEALTH_CHECK_INTERVAL)
 
 
@@ -467,7 +476,8 @@ def _audit_call(server_id: str, tool_name: str, user_id: int | None, ok: bool, e
         if len(_AUDIT_LOG) > _AUDIT_LIMIT:
             del _AUDIT_LOG[:len(_AUDIT_LOG) - _AUDIT_LIMIT]
     except Exception:
-        pass
+        import logging
+        logging.getLogger("rpg.mcp_broker").warning("[mcp] audit log 写入/裁剪失败", exc_info=True)
 
 
 def get_audit_log(user_id: int | None = None, limit: int = 100) -> list[dict[str, Any]]:

--- a/rpg/redis_bus.py
+++ b/rpg/redis_bus.py
@@ -134,7 +134,7 @@ def rate_reset(key: str) -> None:
     try:
         cli.delete(f"rpg:rl:{key}")
     except Exception:
-        pass
+        log.debug("[redis] rate_reset delete 失败 key=%s", key, exc_info=True)
 
 
 # ── 锁定键(登录失败锁定等,带 TTL 自动解锁)────────────────────────────────
@@ -170,7 +170,7 @@ def lock_clear(name: str) -> None:
     try:
         cli.delete(f"rpg:lock:{name}")
     except Exception:
-        pass
+        log.debug("[redis] lock_clear delete 失败 name=%s", name, exc_info=True)
 
 
 # ── 跨进程并发信号量(令牌列表 + 阻塞 BLPOP)──────────────────────────────
@@ -276,7 +276,7 @@ def sem_release(name: str, token: str) -> None:
     try:
         cli.rpush(f"rpg:sem:{name}:tokens", token)
     except Exception:
-        pass
+        log.debug("[redis] semaphore_release rpush 失败 name=%s", name, exc_info=True)
 
 
 __all__ = [

--- a/rpg/skill_executor.py
+++ b/rpg/skill_executor.py
@@ -3,12 +3,12 @@ skill_executor.py — Skill 沙箱执行
 
 设计目标（来自交接 TODO #10）：
 - subprocess 隔离：禁止访问主项目 working tree
-- 资源限制：CPU 时间、内存、文件大小、open files
 - 超时：默认 30s，最大 300s
 - stdout/stderr 捕获 + 截断
 - 临时工作目录：执行完自动清理
 - 输出大小限制：避免 stdout 炸内存
 - 环境变量白名单：只传必要的 PATH 和 LANG
+- 资源限制（CPU/内存/文件）由外部沙箱层负责（Docker / nsjail / firejail）
 
 不防御的事：
 - 网络访问（靠容器/防火墙层面）
@@ -20,7 +20,6 @@ skill_executor.py — Skill 沙箱执行
 from __future__ import annotations
 
 import os
-import resource
 import shutil
 import subprocess
 import tempfile
@@ -33,10 +32,6 @@ DEFAULT_TIMEOUT_SEC = 30
 MAX_TIMEOUT_SEC = 300
 MAX_STDOUT_BYTES = 1 * 1024 * 1024   # 1 MB
 MAX_STDERR_BYTES = 256 * 1024         # 256 KB
-RLIMIT_CPU_SEC = 60                   # CPU 时间硬限制（秒）
-RLIMIT_AS_BYTES = 512 * 1024 * 1024   # 地址空间（虚拟内存）512 MB
-RLIMIT_FSIZE_BYTES = 16 * 1024 * 1024 # 单文件最大 16 MB
-RLIMIT_NOFILE = 64                    # open files
 
 
 # 环境变量白名单：只传这些，其他全砍掉。
@@ -56,31 +51,6 @@ def _build_env(extra: dict[str, str] | None = None) -> dict[str, str]:
             if isinstance(v, str) and len(v) < 4096:
                 env[k] = v
     return env
-
-
-def _preexec_setrlimit():
-    """子进程 fork 后、exec 前调用。设置资源限制。"""
-    try:
-        resource.setrlimit(resource.RLIMIT_CPU, (RLIMIT_CPU_SEC, RLIMIT_CPU_SEC))
-    except Exception:
-        pass
-    try:
-        resource.setrlimit(resource.RLIMIT_AS, (RLIMIT_AS_BYTES, RLIMIT_AS_BYTES))
-    except Exception:
-        pass
-    try:
-        resource.setrlimit(resource.RLIMIT_FSIZE, (RLIMIT_FSIZE_BYTES, RLIMIT_FSIZE_BYTES))
-    except Exception:
-        pass
-    try:
-        resource.setrlimit(resource.RLIMIT_NOFILE, (RLIMIT_NOFILE, RLIMIT_NOFILE))
-    except Exception:
-        pass
-    # 与父进程脱离会话，防止 Ctrl+C 误传
-    try:
-        os.setsid()
-    except Exception:
-        pass
 
 
 def run_skill_command(
@@ -152,7 +122,6 @@ def run_skill_command(
                 stdin=subprocess.PIPE if stdin_text else subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                preexec_fn=_preexec_setrlimit,
                 start_new_session=True,
                 text=True,
                 encoding="utf-8",

--- a/rpg/state_event_bus.py
+++ b/rpg/state_event_bus.py
@@ -108,7 +108,8 @@ def _deliver(q: asyncio.Queue[StateEvent], event: StateEvent) -> None:
             q.get_nowait()
             q.put_nowait(event)
         except Exception:
-            pass
+            import logging
+            logging.getLogger("rpg.state_event_bus").debug("_try_put 背压替换失败,丢弃事件")
 
 
 def _local_emit(event: StateEvent) -> None:
@@ -152,7 +153,10 @@ def emit(user_id: int, topic: str, op: str, payload: dict[str, Any] | None = Non
             )
             redis_bus.publish_event(wire)
     except Exception:
-        pass
+        import logging
+        logging.getLogger("rpg.state_event_bus").warning(
+            "Redis 跨进程投递失败 user_id=%s topic=%s", user_id, topic, exc_info=True
+        )
 
 
 async def redis_listener() -> None:
@@ -211,7 +215,7 @@ async def redis_listener() -> None:
                     try:
                         await _c.aclose()
                     except Exception:
-                        pass
+                        _log.debug("Redis 连接关闭失败(cleanup 路径,忽略)")
 
 
 def subscriber_count(user_id: int) -> int:

--- a/rpg/tests/unit/test_except_handler_scope.py
+++ b/rpg/tests/unit/test_except_handler_scope.py
@@ -1,0 +1,104 @@
+"""
+test_except_handler_scope.py —— except 处理块不许引用「只在 try 内绑定」的局部变量。
+
+来源:OSS PR #98(dragonjay-lyj)把静默 `except Exception: pass` 改成打日志 —— 方向对,
+但其中两处日志引用了在 try **内部**才赋值的变量:
+
+    try:
+        from platform_app.cluster import request_stop      # ← 这行抛的话
+        current_run = _lru_get(...)                        # ← 就没执行到
+    except Exception:
+        log.warning(..., current_run, ...)                 # ← UnboundLocalError
+
+结果是把本来被吞掉的错误升级成真崩溃 —— 比原来的 `pass` 更糟。
+维护者已修(在 try 之前先绑定),这里用 AST 锁死,防止同类写法再回流。
+"""
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+RPG = Path(__file__).resolve().parents[2]
+SKIP_DIRS = ("tests/", "claude_design_upload/")
+
+
+def _names_bound_before(node_body: list[ast.stmt], upto: ast.stmt) -> set[str]:
+    """同级语句中,排在 upto 之前的赋值/for/with 目标名。"""
+    out: set[str] = set()
+    for stmt in node_body:
+        if stmt is upto:
+            break
+        for sub in ast.walk(stmt):
+            if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Store):
+                out.add(sub.id)
+    return out
+
+
+def _scan(tree: ast.AST, src_name: str) -> list[str]:
+    problems: list[str] = []
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Module)):
+            continue
+        params: set[str] = set()
+        if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            a = fn.args
+            params = {x.arg for x in [*a.posonlyargs, *a.args, *a.kwonlyargs]}
+            if a.vararg: params.add(a.vararg.arg)
+            if a.kwarg: params.add(a.kwarg.arg)
+        for parent in ast.walk(fn):
+            body = getattr(parent, "body", None)
+            if not isinstance(body, list):
+                continue
+            for stmt in body:
+                if not isinstance(stmt, ast.Try):
+                    continue
+                bound_in_try = {
+                    n.id for s in stmt.body for n in ast.walk(s)
+                    if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store)
+                }
+                outer = _names_bound_before(body, stmt) | params
+                for handler in stmt.handlers:
+                    local = set(outer)
+                    if handler.name:
+                        local.add(handler.name)
+                    # handler 自己绑定的名字要排除:大量正常写法是在 except 里先重新赋值
+                    # 再使用(如 `out = {...}` 兜底、`with connect() as db:` 重开连接)。
+                    # 保守起见按整个 handler 的 Store 集合算,宁可漏报也不误报。
+                    local |= {
+                        n.id for n in ast.walk(handler)
+                        if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store)
+                    }
+                    local |= {
+                        (n.optional_vars.id if isinstance(getattr(n, "optional_vars", None), ast.Name) else "")
+                        for n in ast.walk(handler) if isinstance(n, ast.withitem)
+                    }
+                    for n in ast.walk(handler):
+                        if not (isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)):
+                            continue
+                        if n.id in bound_in_try and n.id not in local:
+                            problems.append(f"{src_name}:{n.lineno} except 引用了只在 try 内绑定的 {n.id!r}")
+    return problems
+
+
+class ExceptHandlersDontReferenceTryLocals(unittest.TestCase):
+    def test_no_unbound_local_in_except(self):
+        problems: list[str] = []
+        for path in sorted(RPG.rglob("*.py")):
+            rel = path.relative_to(RPG).as_posix()
+            if rel.startswith(SKIP_DIRS):
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+            except SyntaxError:
+                continue
+            problems.extend(_scan(tree, rel))
+        self.assertEqual(
+            problems, [],
+            "except 里引用 try 内才赋值的变量 → 异常发生在赋值之前时抛 UnboundLocalError,"
+            "把被吞的错误升级成崩溃。请在 try 之前先绑定默认值:\n  " + "\n  ".join(problems),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replace bare except Exception: pass with log.warning/log.debug across core infrastructure files to improve observability:

app.py (11 locations):
- load_preferences DB failure
- request_stop failure
- snapshot state recovery failure
- model resolution fallbacks
- context run status update
- console assistant model override / BYOK guard

mcp_broker.py (4 locations):
- process terminate/kill failure
- tools/list refresh failure
- health loop exception
- audit log write failure

state_event_bus.py (3 locations):
- queue backpressure fallback
- Redis cross-process publish failure
- Redis connection close failure

redis_bus.py (3 locations):
- rate_reset, lock_clear, semaphore_release failures

skill_executor.py:
- Remove preexec_fn (Unix-only, breaks on Windows)
- Remove dead code (_preexec_setrlimit, RLIMIT_* constants)
- Update docstring: resource limits delegated to external sandbox