### PR TITLE
fix: replace production assert with explicit raise, sync desktop version

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rpg-roleplay-desktop",
   "productName": "RPG Roleplay",
-  "version": "1.67.6",
+  "version": "1.78.7",
   "description": "RPG Roleplay 本地一键部署桌面服务端(出品 Stellatrix Labs)—— 在线模式连云端,本地模式起捆绑的 PostgreSQL + Python 后端",
   "private": true,
   "main": "src/main.js",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rpg-roleplay-desktop",
   "productName": "RPG Roleplay",
-  "version": "1.78.7",
+  "version": "1.79.0",
   "description": "RPG Roleplay 本地一键部署桌面服务端(出品 Stellatrix Labs)—— 在线模式连云端,本地模式起捆绑的 PostgreSQL + Python 后端",
   "private": true,
   "main": "src/main.js",

--- a/rpg/core/outbound.py
+++ b/rpg/core/outbound.py
@@ -77,7 +77,8 @@ def _resolve_external_ip(host: str, port: int) -> str:
             )
         if pinned is None:
             pinned = ip_str
-    assert pinned is not None  # 上面非空且全过校验 → 必有值
+    if pinned is None:
+        raise OutboundBlocked(f"出站目标解析后无有效公网 IP:{host}")
     return pinned
 
 

--- a/rpg/platform_app/assets_registry.py
+++ b/rpg/platform_app/assets_registry.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from .db import connect, init_db, limit_value
 
-
 # ---------------------------------------------------------------------------
 # 写：登记 / 幂等 upsert
 # ---------------------------------------------------------------------------
@@ -67,7 +66,8 @@ def register_asset(
                 "meta":        Jsonb(meta_val),
             },
         ).fetchone()
-    assert row is not None
+    if row is None:
+        raise RuntimeError(f"assets_registry: insert/upsert 未返回行 (storage_key={storage_key!r})")
     return int(row["id"])
 
 


### PR DESCRIPTION
- outbound.py: assert pinned is not None → raise OutboundBlocked Prevents SSRF bypass when python -O is used
- assets_registry.py: assert row is not None → raise RuntimeError Prevents silent None propagation on insert failure
- desktop/package.json: version 1.67.6 → 1.78.7 Match backend/frontend version