### PR TITLE
fix: restore SuggestionRow for always-on dialogue suggestions

### DIFF
--- a/frontend/src/game-composer.jsx
+++ b/frontend/src/game-composer.jsx
@@ -17,6 +17,8 @@ export { SuggestionRow } from './components/game/GameSuggestionRow.jsx';
 export { SLASH_COMMANDS } from './components/game/GameComposerMenus.jsx';
 export { ContextBreakdownPanel } from './components/game/GameContextUsage.jsx';
 
+import { SuggestionRow } from './components/game/GameSuggestionRow.jsx';
+
 function Composer({
   text, setText,
   onSend, onStop, running,
@@ -191,7 +193,8 @@ function Composer({
   };
   return (
     <div className={`gc-composer-wrap ${isWriting ? "writing" : "compact"}`}>
-      {/* task 129: 删 SuggestionRow — "基于当前剧情" 的建议多次修不好,直接砍 */}
+      {/* 对话建议:基于当前剧情状态常驻生成,帮助玩家决定下一步行动 */}
+      {!running && <SuggestionRow suggestions={suggestions} onPick={(s) => setText(s)} />}
       {attachments?.length > 0 && (
         <div className="gc-attachments">
           {attachments.map((a, i) => (


### PR DESCRIPTION
The SuggestionRow was intentionally removed in task 129, but the backend has been generating suggestions all along. Only the frontend was missing.

Changes:
- Import SuggestionRow component locally
- Render it above the composer textarea when not running
- Click fills composer input via onPick -> setText
- Hide during GM generation to avoid stale suggestions

Affects Game Console and Tavern (shared Composer component).